### PR TITLE
Travis-CI: Work around issue with Maven

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ before_install:
   - "if [ \"$DMG\" = \"1\" ]; then wget \"http://download.mono-project.com/archive/${MONO_VERSION}/macos-10-x86/MonoFramework-MDK-${MONO_VERSION}.macos10.xamarin.x86.dmg\"; fi"
   - "if [ \"$DMG\" = \"1\" ]; then hdid \"MonoFramework-MDK-${MONO_VERSION}.macos10.xamarin.x86.dmg\"; fi"
   - "if [ \"$DMG\" = \"1\" ]; then sudo installer -pkg \"/Volumes/Mono Framework MDK ${MONO_VERSION}/MonoFramework-MDK-${MONO_VERSION}.macos10.xamarin.x86.pkg\" -target /; fi"
+  # https://github.com/travis-ci/travis-ci/issues/2839
+  - export JAVA_HOME="$(/usr/libexec/java_home)"
 
 script: "make"
 


### PR DESCRIPTION
Recent builds have failed due to a bug in Maven. Setting `JAVA_HOME` is a temporary fix.