### PR TITLE
Removed dependency on info.cukes:gherkin-jvm-deps and placed GenerateAst under test

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -18,7 +18,7 @@ all: .compared
 
 acceptance/testdata/%.feature.tokens: ../testdata/%.feature ../testdata/%.feature.tokens .built
 	mkdir -p `dirname $@`
-	java -classpath ~/.m2/repository/info/cukes/gherkin-jvm-deps/1.0.3/gherkin-jvm-deps-1.0.3.jar:target/classes gherkin.GenerateTokens $< > $@
+	java -classpath ~/.m2/repository/com/google/code/gson/gson/2.3.1/gson-2.3.1.jar:target/classes gherkin.GenerateTokens $< > $@
 	diff --unified --ignore-all-space $<.tokens $@
 .DELETE_ON_ERROR: acceptance/testdata/%.feature.tokens
 
@@ -26,7 +26,7 @@ acceptance/testdata/%.feature.ast.json: ../testdata/%.feature ../testdata/%.feat
 	mkdir -p `dirname $@`
 	java \
 	    -javaagent:jacoco/jacocoagent.jar=destfile=target/jacoco.exec \
-	    -classpath ~/.m2/repository/info/cukes/gherkin-jvm-deps/1.0.3/gherkin-jvm-deps-1.0.3.jar:target/classes \
+	    -classpath ~/.m2/repository/com/google/code/gson/gson/2.3.1/gson-2.3.1.jar:target/classes \
 	    gherkin.GenerateAst $< | jq --sort-keys "." > $@
 	diff --unified --ignore-all-space $<.ast.json $@
 .DELETE_ON_ERROR: acceptance/testdata/%.feature.ast.json

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -30,20 +30,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>info.cukes</groupId>
-            <artifactId>gherkin-jvm-deps</artifactId>
-            <version>1.0.3</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.code.gson</groupId>
-                    <artifactId>gson</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>net.iharder</groupId>
-                    <artifactId>base64</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.3.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/java/src/main/java/gherkin/GenerateAst.java
+++ b/java/src/main/java/gherkin/GenerateAst.java
@@ -1,7 +1,7 @@
 package gherkin;
 
 import gherkin.ast.Feature;
-import gherkin.deps.com.google.gson.Gson;
+import com.google.gson.Gson;
 
 import java.io.FileInputStream;
 import java.io.IOException;

--- a/java/src/main/java/gherkin/GherkinDialectProvider.java
+++ b/java/src/main/java/gherkin/GherkinDialectProvider.java
@@ -1,6 +1,6 @@
 package gherkin;
 
-import gherkin.deps.com.google.gson.Gson;
+import com.google.gson.Gson;
 
 import java.io.InputStreamReader;
 import java.io.Reader;

--- a/java/src/test/java/gherkin/GenerateAstTest.java
+++ b/java/src/test/java/gherkin/GenerateAstTest.java
@@ -1,0 +1,69 @@
+package gherkin;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+
+public class GenerateAstTest {
+    @Test
+    public void parse_all_good_features() throws IOException {
+        String[] args = getAllGoodTestFeatures();
+
+        GenerateAst.main(args);
+    }
+
+    @Test(expected = ParserException.CompositeParserException.class)
+    public void fail_on_inconsistent_cell_count() throws IOException {
+        String[] args = {"../testdata/bad/inconsistent_cell_count.feature"};
+
+        GenerateAst.main(args);
+    }
+
+    @Test(expected = ParserException.CompositeParserException.class)
+    public void fail_on_multiple_parser_errors() throws IOException {
+        String[] args = {"../testdata/bad/multiple_parser_errors.feature"};
+
+        GenerateAst.main(args);
+    }
+
+    @Test(expected = ParserException.CompositeParserException.class)
+    public void fail_on_single_parser_error() throws IOException {
+        String[] args = {"../testdata/bad/single_parser_error.feature"};
+
+        GenerateAst.main(args);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void fail_on_invalid_language() throws IOException {
+        String[] args = {"../testdata/bad/invalid_language.feature"};
+
+        GenerateAst.main(args);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void fail_on_unexpected_eof() throws IOException {
+        String[] args = {"../testdata/bad/unexpected_eof.feature"};
+
+        GenerateAst.main(args);
+    }
+
+    private String[] getAllGoodTestFeatures() throws IOException {
+        File dir = new File("../testdata/good/");
+        File[] files = dir.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir11, String name) {
+                return name.endsWith(".feature");
+            }
+        });
+
+        String[] args = new String[files.length];
+
+        for (int index = 0; index < files.length; index++) {
+            args[index] = files[index].getCanonicalPath();
+        }
+
+        return args;
+    }
+}


### PR DESCRIPTION
I am not sure if it was this way you intended to remove the dependency on info.cukes:gherkin-jvm-deps, but it is one way to do it.

While I was at it, I added some unit tests for GenerateAst and noticed that I think there are two bugs. There are two cases where a NullPointerException is thrown when the bad features are parsed. I am pretty certain that it should be some other exception. I am, however, not entirely sure where these other exceptions should be thrown. Look into the GenerateAstTest and you will see that NullPointerException is expected for two tests. This feels very wrong, but it is a documentation on the current behavior.