### PR TITLE
Unit tests for java parser

### DIFF
--- a/java/src/main/java/gherkin/GherkinDialectProvider.java
+++ b/java/src/main/java/gherkin/GherkinDialectProvider.java
@@ -28,6 +28,10 @@ public class GherkinDialectProvider implements IGherkinDialectProvider {
     @Override
     public GherkinDialect getDialect(String language) {
         Map<String, List<String>> map = DIALECTS.get(language);
+        if (map == null) {
+            throw new ParserException("No such language: " + language);
+        }
+
         return new GherkinDialect(language, map);
     }
 }

--- a/java/src/main/java/gherkin/TokenMatcher.java
+++ b/java/src/main/java/gherkin/TokenMatcher.java
@@ -61,6 +61,9 @@ public class TokenMatcher implements ITokenMatcher {
 
     @Override
     public boolean match_Empty(Token token) {
+        if (token.IsEOF()) {
+            return false;
+        }
         if (token.line.IsEmpty()) {
             SetTokenMatched(token, TokenType.Empty);
             return true;
@@ -70,6 +73,9 @@ public class TokenMatcher implements ITokenMatcher {
 
     @Override
     public boolean match_Comment(Token token) {
+        if (token.IsEOF()) {
+            return false;
+        }
         if (token.line.StartsWith(GherkinLanguageConstants.COMMENT_PREFIX)) {
             String text = token.line.GetLineText(0); //take the entire line
             SetTokenMatched(token, TokenType.Comment, text, null, 0, null);
@@ -98,6 +104,9 @@ public class TokenMatcher implements ITokenMatcher {
 
     @Override
     public boolean match_TagLine(Token token) {
+        if (token.IsEOF()){
+            return false;
+        }
         if (token.line.StartsWith(GherkinLanguageConstants.TAG_PREFIX)) {
             SetTokenMatched(token, TokenType.TagLine, null, null, null, token.line.GetTags());
             return true;
@@ -164,6 +173,9 @@ public class TokenMatcher implements ITokenMatcher {
 
     private boolean matchTitleLine(Token token, TokenType tokenType, List<String> keywords) {
         for (String keyword : keywords) {
+            if (token.IsEOF()) {
+                return false;
+            }
             if (token.line.StartsWithTitleKeyword(keyword)) {
                 String title = token.line.GetRestTrimmed(keyword.length() + GherkinLanguageConstants.TITLE_KEYWORD_SEPARATOR.length());
                 SetTokenMatched(token, tokenType, title, keyword, null, null);
@@ -183,6 +195,9 @@ public class TokenMatcher implements ITokenMatcher {
     }
 
     private boolean match_DocStringSeparator(Token token, String separator, boolean isOpen) {
+        if (token.IsEOF()){
+            return false;
+        }
         if (token.line.StartsWith(separator)) {
             String contentType = null;
             if (isOpen) {
@@ -204,6 +219,9 @@ public class TokenMatcher implements ITokenMatcher {
     public boolean match_StepLine(Token token) {
         List<String> keywords = currentDialect.getStepKeywords();
         for (String keyword : keywords) {
+            if(token.IsEOF()){
+                return false;
+            }
             if (token.line.StartsWith(keyword)) {
                 String stepText = token.line.GetRestTrimmed(keyword.length());
                 SetTokenMatched(token, TokenType.StepLine, stepText, keyword, null, null);
@@ -214,6 +232,9 @@ public class TokenMatcher implements ITokenMatcher {
     }
 
     public boolean match_TableRow(Token token) {
+        if (token.IsEOF()) {
+            return false;
+        }
         if (token.line.StartsWith(GherkinLanguageConstants.TABLE_CELL_SEPARATOR)) {
             SetTokenMatched(token, TokenType.TableRow, null, null, null, token.line.GetTableCells());
             return true;

--- a/java/src/test/java/gherkin/ParserTest.java
+++ b/java/src/test/java/gherkin/ParserTest.java
@@ -57,4 +57,19 @@ public class ParserTest {
             assertThat(actualMessage, is("Parser errors: \nNo such language: no-such"));
         }
     }
+
+    @Test
+    public void fail_parser_on_unexpected_eof() {
+        Parser<Feature> parser = new Parser<>();
+
+        try {
+            parser.parse("Feature: Unexpected end of file\n" +
+                    "\n" +
+                    "  Scenario Outline: minimalistic\n" +
+                    "    Given the minimalism\n");
+        } catch (ParserException.CompositeParserException e) {
+            String actualMessage = e.getMessage();
+            assertThat(actualMessage, is("Parser errors: \n(5:0): unexpected end of file, expected: #TableRow, #DocStringSeparator, #StepLine, #TagLine, #ExamplesLine, #Comment, #Empty"));
+        }
+    }
 }

--- a/java/src/test/java/gherkin/ParserTest.java
+++ b/java/src/test/java/gherkin/ParserTest.java
@@ -6,7 +6,9 @@ import gherkin.ast.Scenario;
 import gherkin.ast.Step;
 import org.junit.Test;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class ParserTest {
     @Test
@@ -37,5 +39,22 @@ public class ParserTest {
 
         DataTable table = (DataTable) step.getArgument();
         assertEquals("a", table.getRows().get(0).getCells().get(0).getValue());
+    }
+
+    @Test
+    public void fail_parser_on_invalid_language_feature() {
+        Parser<Feature> parser = new Parser<>();
+
+        try {
+            parser.parse("#language:no-such\n" +
+                    "\n" +
+                    "Feature: Minimal\n" +
+                    "\n" +
+                    "  Scenario: minimalistic\n" +
+                    "    Given the minimalism\n");
+        } catch (ParserException.CompositeParserException e) {
+            String actualMessage = e.getMessage();
+            assertThat(actualMessage, is("Parser errors: \nNo such language: no-such"));
+        }
     }
 }


### PR DESCRIPTION
Tracked down two different NullPointerExceptions when parsing a feature
* One when the language was missing
* One when the table for a Scenario Outline was missing

I committed them in two commits so they should be easier to cherry pick.

I am not certain about the solution for the missing table in the Scenario Outline. The only option I could find, except the one I used, was to wrap the logic in Parser.matchTokenAt_20 with a try catch, catch NullPointerException and repackage the NPE as a ParserException.UnexpectedEOFException. It got ugly.

Instead I went through the methods called in TokenMatcher and made sure token.line wasn't called without checking for eof on the token. That solution felt better compared to wrap a lot of logic and assume that the NPE caught was due to an unexpected eof.