### PR TITLE
add build scripts to programmatically create files ace editor can consume

### DIFF
--- a/javascript/Makefile
+++ b/javascript/Makefile
@@ -55,6 +55,9 @@ dist/gherkin.js: lib/gherkin/parser.js ../LICENSE node_modules/.fetched
 	echo '*/' >> $@
 	./node_modules/.bin/browserify index.js --ignore-missing >> $@
 
+ace: lib/gherkin/parser.js ../LICENSE node_modules/.fetched
+	./node_modules/.bin/gulp
+
 dist/gherkin.min.js: dist/gherkin.js node_modules/.fetched
 	mkdir -p `dirname $@`
 	echo '/*' > $@

--- a/javascript/Makefile
+++ b/javascript/Makefile
@@ -13,7 +13,7 @@ all: .compared
 .compared: .built $(TOKENS) $(ASTS) $(ERRORS)
 	touch $@
 
-.built: lib/gherkin/parser.js lib/gherkin/dialects.json $(JAVASCRIPT_FILES) dist/gherkin.js dist/gherkin.min.js node_modules/.fetched
+.built: lib/gherkin/parser.js lib/gherkin/dialects.json $(JAVASCRIPT_FILES) dist/gherkin.js dist/gherkin.min.js dist/gherkin/parser.js node_modules/.fetched
 	./node_modules/.bin/mocha
 	touch $@
 
@@ -55,7 +55,7 @@ dist/gherkin.js: lib/gherkin/parser.js ../LICENSE node_modules/.fetched
 	echo '*/' >> $@
 	./node_modules/.bin/browserify index.js --ignore-missing >> $@
 
-ace: lib/gherkin/parser.js ../LICENSE node_modules/.fetched
+dist/gherkin/parser.js: lib/gherkin/parser.js ../LICENSE node_modules/.fetched
 	./node_modules/.bin/gulp
 
 dist/gherkin.min.js: dist/gherkin.js node_modules/.fetched

--- a/javascript/gulpfile.js
+++ b/javascript/gulpfile.js
@@ -1,0 +1,63 @@
+var gulp = require('gulp');
+var wrap = require('gulp-wrap-amd');
+var through = require('through2');
+var path = require('path');
+var fs = require('fs');
+
+function replaceAll(str, find, replace) {
+  return str.split(find).join(replace);
+}
+
+gulp.task('wrap:gherkin', function () {
+  gulp.src('./lib/**/*.js')
+    .pipe(through.obj(function (file, enc, cb) {
+      if (file.isNull()) {
+        cb(null, file);
+        return;
+      }
+
+      var fileName = path.basename(file.path);
+      var newFileContents = replaceAll(file.contents.toString(), "require('tea-error')", "require('./tea/error')");
+
+      if (fileName === 'token_matcher.js') {
+        // token_matcher.js requires a json file. To make the file browser compatible, we need to paste the
+        // contents of the json file into the js file
+        return fs.readFile(path.join(__dirname, 'lib/gherkin/dialects.json'), 'utf8', function (err, data) {
+          if (err) throw err;
+          file.contents = new Buffer(replaceAll(newFileContents, "require('./dialects.json')", data.trim()));
+          cb(null, file);
+        });
+      }
+
+      file.contents = new Buffer(newFileContents);
+      cb(null, file);
+    }))
+    .pipe(wrap({
+      exports: 'module.exports'
+    }))
+    .pipe(gulp.dest('./dist/'))
+});
+
+gulp.task('wrap:node_modules', function () {
+  gulp.src([
+    './node_modules/tea-error/lib/error.js',
+    './node_modules/tea-error/node_modules/tea-extend/lib/extend.js'
+  ])
+    .pipe(through.obj(function (file, enc, cb) {
+      if (file.isNull()) {
+        cb(null, file);
+        return;
+      }
+
+      var newFileContents = replaceAll(file.contents.toString(), "require('tea-extend')", "require('./extend')");
+      file.contents = new Buffer(newFileContents);
+
+      cb(null, file);
+    }))
+    .pipe(wrap({
+      exports: 'module.exports'
+    }))
+    .pipe(gulp.dest('./dist/gherkin/tea'))
+});
+
+gulp.task('default', ['wrap:gherkin', 'wrap:node_modules']);

--- a/javascript/gulpfile.js
+++ b/javascript/gulpfile.js
@@ -4,7 +4,9 @@ var through = require('through2');
 var path = require('path');
 var fs = require('fs');
 var insert = require('gulp-insert');
-var license = fs.readFileSync(path.join(__dirname, '../LICENSE'), 'utf8');
+var rename = require('gulp-rename');
+var licensePath = path.join(__dirname, '../LICENSE');
+var license = fs.readFileSync(licensePath, 'utf8');
 
 function replaceAll(str, find, replace) {
   return str.split(find).join(replace);
@@ -63,4 +65,13 @@ gulp.task('wrap:node_modules', function () {
     .pipe(gulp.dest('./dist/gherkin/tea'))
 });
 
-gulp.task('default', ['wrap:gherkin', 'wrap:node_modules']);
+gulp.task('stand-alone-license', function () {
+  gulp.src(licensePath)
+    .pipe(rename({
+      extname: ".gherkin"
+    }))
+    .pipe(insert.prepend('This license pertains to the file worker-gherkin.js.\n\n'))
+    .pipe(gulp.dest('./dist/gherkin'))
+});
+
+gulp.task('default', ['wrap:gherkin', 'wrap:node_modules', 'stand-alone-license']);

--- a/javascript/gulpfile.js
+++ b/javascript/gulpfile.js
@@ -3,6 +3,8 @@ var wrap = require('gulp-wrap-amd');
 var through = require('through2');
 var path = require('path');
 var fs = require('fs');
+var insert = require('gulp-insert');
+var license = fs.readFileSync(path.join(__dirname, '../LICENSE'), 'utf8');
 
 function replaceAll(str, find, replace) {
   return str.split(find).join(replace);
@@ -35,6 +37,7 @@ gulp.task('wrap:gherkin', function () {
     .pipe(wrap({
       exports: 'module.exports'
     }))
+    .pipe(insert.prepend('/*\n' + license + '*/\n'))
     .pipe(gulp.dest('./dist/'))
 });
 

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -22,7 +22,10 @@
   "homepage": "https://github.com/cucumber/gherkin3",
   "devDependencies": {
     "browserify": "^9.0.3",
+    "gulp": "^3.8.11",
+    "gulp-wrap-amd": "^0.5.0",
     "mocha": "^2.1.0",
+    "through2": "^0.6.3",
     "uglify-js": "^2.4.19"
   },
   "dependencies": {

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "browserify": "^9.0.3",
     "gulp": "^3.8.11",
+    "gulp-insert": "^0.4.0",
     "gulp-wrap-amd": "^0.5.0",
     "mocha": "^2.1.0",
     "through2": "^0.6.3",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -24,6 +24,7 @@
     "browserify": "^9.0.3",
     "gulp": "^3.8.11",
     "gulp-insert": "^0.4.0",
+    "gulp-rename": "^1.2.2",
     "gulp-wrap-amd": "^0.5.0",
     "mocha": "^2.1.0",
     "through2": "^0.6.3",


### PR DESCRIPTION
First, install the new tools by running `npm install`.

now, running `gulp` from `gherkin3/javascript` will generate a `dist/gherkin/` folder containing all the files which can be dropped wholesale into the [ace project under `lib/ace/mode/gherkin/`](https://github.com/chmontgomery/ace/tree/feature/gherkin-worker/lib/ace/mode/gherkin)

This change depends on https://github.com/cucumber/gherkin3/pull/7 and https://github.com/cucumber/gherkin3/issues/8