### PR TITLE
Gracefully report parser error when file not gherkin

### DIFF
--- a/dotnet/Gherkin/AstBuilder.cs
+++ b/dotnet/Gherkin/AstBuilder.cs
@@ -112,7 +112,7 @@ namespace Gherkin
                     var examplesNode = node.GetSingle<AstNode>(RuleType.Examples);
                     var examplesLine = examplesNode.GetToken(TokenType.ExamplesLine);
                     var description = GetDescription(examplesNode);
- 
+
                     var allRows = GetTableRows(examplesNode);
                     var header = allRows.First();
                     var rows = allRows.Skip(1).ToArray();
@@ -130,11 +130,14 @@ namespace Gherkin
                 case RuleType.Feature:
                 {
                     var header = node.GetSingle<AstNode>(RuleType.Feature_Header);
+                    if(header == null) return null;
                     var tags = GetTags(header);
                     var featureLine = header.GetToken(TokenType.FeatureLine);
+                    if(featureLine == null) return null;
                     var background = node.GetSingle<Background>(RuleType.Background);
                     var scenariodefinitions = node.GetItems<ScenarioDefinition>(RuleType.Scenario_Definition).ToArray();
                     var description = GetDescription(header);
+                    if(featureLine.MatchedGherkinDialect == null) return null;
                     var language = featureLine.MatchedGherkinDialect.Language;
 
                     return new Feature(tags, GetLocation(featureLine), language, featureLine.MatchedKeyword, featureLine.MatchedText, description, background, scenariodefinitions, comments.ToArray());

--- a/go/astbuilder.go
+++ b/go/astbuilder.go
@@ -244,14 +244,12 @@ func (t *astBuilder) transformNode(node *astNode) (interface{}, error) {
 	case RuleType_Feature:
 		header, ok := node.getSingle(RuleType_Feature_Header).(*astNode)
 		if !ok {
-			header = &astNode{ruleType: RuleType_Feature_Header}
+			return nil, nil
 		}
 		tags := astTags(header)
 		featureLine := header.getToken(TokenType_FeatureLine)
 		if featureLine == nil {
-			featureLine = new(Token)
-			featureLine.Location = &Location{Line: 1, Column: 1}
-			featureLine.Type = TokenType_FeatureLine
+			return nil, nil
 		}
 		background, _ := node.getSingle(RuleType_Background).(*Background)
 		scenarioDefinitions := node.getItems(RuleType_Scenario_Definition)

--- a/java/src/main/java/gherkin/AstBuilder.java
+++ b/java/src/main/java/gherkin/AstBuilder.java
@@ -144,11 +144,14 @@ public class AstBuilder<T> implements IAstBuilder<T> {
             }
             case Feature: {
                 AstNode header = node.getSingle(RuleType.Feature_Header, new AstNode(RuleType.Feature_Header));
+                if (header == null) return null;
                 List<Tag> tags = getTags(header);
                 Token featureLine = header.getToken(TokenType.FeatureLine);
+                if (featureLine == null) return null;
                 Background background = node.getSingle(RuleType.Background, null);
                 List<ScenarioDefinition> scenarioDefinitions = node.getItems(RuleType.Scenario_Definition);
                 String description = getDescription(header);
+                if (featureLine.matchedGherkinDialect == null) return null;
                 String language = featureLine.matchedGherkinDialect.getLanguage();
 
                 return new Feature(tags, getLocation(featureLine, 0), language, featureLine.matchedKeyword, featureLine.matchedText, description, background, scenarioDefinitions, comments);

--- a/javascript/lib/gherkin/ast_builder.js
+++ b/javascript/lib/gherkin/ast_builder.js
@@ -211,20 +211,20 @@ module.exports = function AstBuilder () {
 
       case 'Feature':
         var header = node.getSingle('Feature_Header');
-        var tags = getTags(header);
-        var featureLine = header.getToken('FeatureLine');
+        var tags = header && getTags(header);
+        var featureLine = header && header.getToken('FeatureLine');
         var background = node.getSingle('Background');
         var scenariodefinitions = node.getItems('Scenario_Definition');
-        var description = getDescription(header);
-        var language = featureLine.matchedGherkinDialect;
+        var description = header && getDescription(header);
+        var language = featureLine && featureLine.matchedGherkinDialect;
 
         return {
           type: node.ruleType,
           tags: tags,
-          location: getLocation(featureLine),
+          location: featureLine && getLocation(featureLine),
           language: language,
-          keyword: featureLine.matchedKeyword,
-          name: featureLine.matchedText,
+          keyword: featureLine && featureLine.matchedKeyword,
+          name: featureLine && featureLine.matchedText,
           description: description,
           background: background,
           scenarioDefinitions: scenariodefinitions,

--- a/javascript/lib/gherkin/ast_builder.js
+++ b/javascript/lib/gherkin/ast_builder.js
@@ -211,20 +211,22 @@ module.exports = function AstBuilder () {
 
       case 'Feature':
         var header = node.getSingle('Feature_Header');
-        var tags = header && getTags(header);
-        var featureLine = header && header.getToken('FeatureLine');
+        if(!header) return null;
+        var tags = getTags(header);
+        var featureLine = header.getToken('FeatureLine');
+        if(!featureLine) return null;
         var background = node.getSingle('Background');
         var scenariodefinitions = node.getItems('Scenario_Definition');
-        var description = header && getDescription(header);
-        var language = featureLine && featureLine.matchedGherkinDialect;
+        var description = getDescription(header);
+        var language = featureLine.matchedGherkinDialect;
 
         return {
           type: node.ruleType,
           tags: tags,
-          location: featureLine && getLocation(featureLine),
+          location: getLocation(featureLine),
           language: language,
-          keyword: featureLine && featureLine.matchedKeyword,
-          name: featureLine && featureLine.matchedText,
+          keyword: featureLine.matchedKeyword,
+          name: featureLine.matchedText,
           description: description,
           background: background,
           scenarioDefinitions: scenariodefinitions,

--- a/ruby/lib/gherkin/ast_builder.rb
+++ b/ruby/lib/gherkin/ast_builder.rb
@@ -206,20 +206,22 @@ module Gherkin
         return description
       when :Feature
         header = node.get_single(:Feature_Header)
-        tags = header && get_tags(header)
-        feature_line = header && header.get_token(:FeatureLine)
+        return unless header
+        tags = get_tags(header)
+        feature_line = header.get_token(:FeatureLine)
+        return unless feature_line
         background = node.get_single(:Background)
         scenario_definitions = node.get_items(:Scenario_Definition)
-        description = header && get_description(header)
-        language = feature_line && feature_line.matched_gherkin_dialect
+        description = get_description(header)
+        language = feature_line.matched_gherkin_dialect
 
         reject_nils(
           type: node.rule_type,
           tags: tags,
-          location: feature_line && get_location(feature_line),
+          location: get_location(feature_line),
           language: language,
-          keyword: feature_line && feature_line.matched_keyword,
-          name: feature_line && feature_line.matched_text,
+          keyword: feature_line.matched_keyword,
+          name: feature_line.matched_text,
           description: description,
           background: background,
           scenarioDefinitions: scenario_definitions,

--- a/ruby/lib/gherkin/ast_builder.rb
+++ b/ruby/lib/gherkin/ast_builder.rb
@@ -206,20 +206,20 @@ module Gherkin
         return description
       when :Feature
         header = node.get_single(:Feature_Header)
-        tags = get_tags(header)
-        feature_line = header.get_token(:FeatureLine)
+        tags = header && get_tags(header)
+        feature_line = header && header.get_token(:FeatureLine)
         background = node.get_single(:Background)
         scenario_definitions = node.get_items(:Scenario_Definition)
-        description = get_description(header)
-        language = feature_line.matched_gherkin_dialect
+        description = header && get_description(header)
+        language = feature_line && feature_line.matched_gherkin_dialect
 
         reject_nils(
           type: node.rule_type,
           tags: tags,
-          location: get_location(feature_line),
+          location: feature_line && get_location(feature_line),
           language: language,
-          keyword: feature_line.matched_keyword,
-          name: feature_line.matched_text,
+          keyword: feature_line && feature_line.matched_keyword,
+          name: feature_line && feature_line.matched_text,
           description: description,
           background: background,
           scenarioDefinitions: scenario_definitions,

--- a/testdata/bad/empty.feature.errors
+++ b/testdata/bad/empty.feature.errors
@@ -1,0 +1,2 @@
+Parser errors:
+(1:0): unexpected end of file, expected: #Language, #TagLine, #FeatureLine, #Comment, #Empty

--- a/testdata/bad/not_gherkin.feature
+++ b/testdata/bad/not_gherkin.feature
@@ -1,0 +1,2 @@
+not gherkin
+

--- a/testdata/bad/not_gherkin.feature.errors
+++ b/testdata/bad/not_gherkin.feature.errors
@@ -1,0 +1,3 @@
+Parser errors:
+(1:1): expected: #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'not gherkin'
+(3:0): unexpected end of file, expected: #Language, #TagLine, #FeatureLine, #Comment, #Empty


### PR DESCRIPTION
I've started taking a look at using gherkin3 with cucumber-ruby-core,  and I noticed that we weren't handling empty Gherkin documents or trying to parse non-gherkin documents gracefully. This PR adds some acceptance tests for these errors, and includes a fix for ruby/javascript.