### PR TITLE
Markdown support

### DIFF
--- a/java/gherkin-java.razor
+++ b/java/gherkin-java.razor
@@ -53,10 +53,6 @@ public class @Model.ParserClassName<T> {
         @foreach(var rule in Model.RuleSet.TokenRules)
         {<text>        @rule.Name.Replace("#", ""),
 </text>}        ;
-
-        public static TokenType cast(RuleType ruleType) {
-            return TokenType.values()[ruleType.ordinal()];
-        }
     }
 
     public enum RuleType {
@@ -89,37 +85,35 @@ public class @Model.ParserClassName<T> {
         }
     }
 
-    public T parse(String source) {
-        return parse(new StringReader(source));
+    public T parse(String source, ITokenMatcher tokenMatcher) {
+        return parse(new StringReader(source), tokenMatcher);
     }
 
-    public T parse(Reader source) {
+    public T parse(Reader source, ITokenMatcher tokenMatcher) {
         AstBuilder<T> builder = new AstBuilder();
-        return parse(source, builder);
+        return parse(source, builder, tokenMatcher);
     }
 
-    public T parse(Reader source, IAstBuilder<T> builder) {
+    public T parse(Reader source, IAstBuilder<T> builder, ITokenMatcher tokenMatcher) {
         ParserContext context = new ParserContext(
                 new TokenScanner(source),
-                new TokenMatcher(),
+                tokenMatcher,
                 builder,
                 new LinkedList<Token>(),
                 new ArrayList<ParserException>()
         );
 
-        startRule(context, RuleType.@Model.RuleSet.StartRule.Name);
+        startRule(context, RuleType.Feature);
         int state = 0;
         Token token;
-        do
-        {
+        do {
             token = readToken(context);
             state = matchToken(state, token, context);
-        } while(!token.isEOF());
+        } while (!token.isEOF());
 
-        endRule(context, RuleType.@Model.RuleSet.StartRule.Name);
+        endRule(context, RuleType.Feature);
 
-        if (context.errors.size() > 0)
-        {
+        if (context.errors.size() > 0) {
             throw new ParserException.CompositeParserException(context.errors);
         }
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -56,6 +56,12 @@
             <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.rjeschke</groupId>
+            <artifactId>txtmark</artifactId>
+            <version>0.13</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/java/src/main/java/gherkin/GenerateAst.java
+++ b/java/src/main/java/gherkin/GenerateAst.java
@@ -14,8 +14,9 @@ public class GenerateAst {
 
         for (String fileName : args) {
             InputStreamReader in = new InputStreamReader(new FileInputStream(fileName), "UTF-8");
+            Parser.ITokenMatcher tokenMatcher = TokenMatcherFactory.getTokenMatcher(fileName);
             try {
-                Feature feature = parser.parse(in);
+                Feature feature = parser.parse(in, tokenMatcher);
                 System.out.println(gson.toJson(feature));
             } catch (ParserException e) {
                 System.err.println(e.getMessage());

--- a/java/src/main/java/gherkin/GeneratePickles.java
+++ b/java/src/main/java/gherkin/GeneratePickles.java
@@ -20,8 +20,9 @@ public class GeneratePickles {
 
         for (String fileName : args) {
             InputStreamReader in = new InputStreamReader(new FileInputStream(fileName), "UTF-8");
+            Parser.ITokenMatcher tokenMatcher = TokenMatcherFactory.getTokenMatcher(fileName);
             try {
-                Feature feature = parser.parse(in);
+                Feature feature = parser.parse(in, tokenMatcher);
                 pickles.addAll(compiler.compile(feature));
             } catch (ParserException e) {
                 System.err.println(e.getMessage());

--- a/java/src/main/java/gherkin/GenerateTokens.java
+++ b/java/src/main/java/gherkin/GenerateTokens.java
@@ -9,9 +9,10 @@ public class GenerateTokens {
     public static void main(String[] args) throws FileNotFoundException, UnsupportedEncodingException {
         Parser<String> parser = new Parser<>();
         for (String fileName : args) {
+            Parser.ITokenMatcher tokenMatcher = TokenMatcherFactory.getTokenMatcher(fileName);
             InputStreamReader in = new InputStreamReader(new FileInputStream(fileName), "UTF-8");
             TokenFormatterBuilder builder = new TokenFormatterBuilder();
-            String result = parser.parse(in, builder);
+            String result = parser.parse(in, builder, tokenMatcher);
             System.out.print(result);
         }
     }

--- a/java/src/main/java/gherkin/GherkinLine.java
+++ b/java/src/main/java/gherkin/GherkinLine.java
@@ -8,12 +8,10 @@ import static gherkin.StringUtils.ltrim;
 
 public class GherkinLine implements IGherkinLine {
     private final String lineText;
-    private final int lineNumber;
     private final String trimmedLineText;
 
-    public GherkinLine(String lineText, int lineNumber) {
+    public GherkinLine(String lineText) {
         this.lineText = lineText;
-        this.lineNumber = lineNumber;
         this.trimmedLineText = ltrim(lineText);
     }
 
@@ -51,7 +49,7 @@ public class GherkinLine implements IGherkinLine {
 
     @Override
     public List<GherkinLineSpan> getTags() {
-        return getSpans("\\s+");
+        return getSpans(trimmedLineText, "\\s+", indent());
     }
 
     @Override
@@ -66,15 +64,15 @@ public class GherkinLine implements IGherkinLine {
 
     @Override
     public List<GherkinLineSpan> getTableCells() {
-        return getSpans("\\s*\\|\\s*");
+        return getSpans(trimmedLineText, "\\s*\\|\\s*", indent());
     }
 
-    private List<GherkinLineSpan> getSpans(String delimiter) {
-        List<GherkinLineSpan> lineSpans = new ArrayList<GherkinLineSpan>();
-        Scanner scanner = new Scanner(trimmedLineText).useDelimiter(delimiter);
+    public static List<GherkinLineSpan> getSpans(String text, String delimiter, int indent) {
+        List<GherkinLineSpan> lineSpans = new ArrayList<>();
+        Scanner scanner = new Scanner(text).useDelimiter(delimiter);
         while (scanner.hasNext()) {
             String cell = scanner.next();
-            int column = scanner.match().start() + indent() + 1;
+            int column = scanner.match().start() + indent + 1;
             lineSpans.add(new GherkinLineSpan(column, cell));
         }
         return lineSpans;

--- a/java/src/main/java/gherkin/GherkinTokenMatcher.java
+++ b/java/src/main/java/gherkin/GherkinTokenMatcher.java
@@ -1,0 +1,136 @@
+package gherkin;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class GherkinTokenMatcher extends TokenMatcher {
+    private static final Pattern LANGUAGE_PATTERN = Pattern.compile("^\\s*#\\s*language\\s*:\\s*([a-zA-Z\\-_]+)\\s*$");
+    private String activeDocStringSeparator = null;
+    private int indentToRemove = 0;
+
+    @Override
+    public boolean match_Other(Token token) {
+        String text = token.line.getLineText(indentToRemove); //take the entire line, except removing DocString indents
+        setTokenMatched(token, Parser.TokenType.Other, text, null, 0, null);
+        return true;
+    }
+
+    @Override
+    public boolean match_Comment(Token token) {
+        if (token.line.startsWith(GherkinLanguageConstants.COMMENT_PREFIX)) {
+            String text = token.line.getLineText(0); //take the entire line
+            setTokenMatched(token, Parser.TokenType.Comment, text, null, 0, null);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean match_Language(Token token) {
+        Matcher matcher = LANGUAGE_PATTERN.matcher(token.line.getLineText(0));
+        if (matcher.matches()) {
+            String language = matcher.group(1);
+            setTokenMatched(token, Parser.TokenType.Language, language, null, null, null);
+
+            currentDialect = dialectProvider.getDialect(language, token.location);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean match_TagLine(Token token) {
+        if (token.line.startsWith(GherkinLanguageConstants.TAG_PREFIX)) {
+            setTokenMatched(token, Parser.TokenType.TagLine, null, null, null, token.line.getTags());
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean match_FeatureLine(Token token) {
+        return matchTitleLine(token, Parser.TokenType.FeatureLine, currentDialect.getFeatureKeywords());
+    }
+
+    @Override
+    public boolean match_BackgroundLine(Token token) {
+        return matchTitleLine(token, Parser.TokenType.BackgroundLine, currentDialect.getBackgroundKeywords());
+    }
+
+    @Override
+    public boolean match_ScenarioLine(Token token) {
+        return matchTitleLine(token, Parser.TokenType.ScenarioLine, currentDialect.getScenarioKeywords());
+    }
+
+    @Override
+    public boolean match_ScenarioOutlineLine(Token token) {
+        return matchTitleLine(token, Parser.TokenType.ScenarioOutlineLine, currentDialect.getScenarioOutlineKeywords());
+    }
+
+    @Override
+    public boolean match_ExamplesLine(Token token) {
+        return matchTitleLine(token, Parser.TokenType.ExamplesLine, currentDialect.getExamplesKeywords());
+    }
+
+    private boolean matchTitleLine(Token token, Parser.TokenType tokenType, List<String> keywords) {
+        for (String keyword : keywords) {
+            if (token.line.startsWithTitleKeyword(keyword)) {
+                String title = token.line.getRestTrimmed(keyword.length() + GherkinLanguageConstants.TITLE_KEYWORD_SEPARATOR.length());
+                setTokenMatched(token, tokenType, title, keyword, null, null);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean match_DocStringSeparator(Token token) {
+        return activeDocStringSeparator == null
+                // open
+                ? match_DocStringSeparator(token, GherkinLanguageConstants.DOCSTRING_SEPARATOR, true) ||
+                match_DocStringSeparator(token, GherkinLanguageConstants.DOCSTRING_ALTERNATIVE_SEPARATOR, true)
+                // close
+                : match_DocStringSeparator(token, activeDocStringSeparator, false);
+    }
+
+    private boolean match_DocStringSeparator(Token token, String separator, boolean isOpen) {
+        if (token.line.startsWith(separator)) {
+            String contentType = null;
+            if (isOpen) {
+                contentType = token.line.getRestTrimmed(separator.length());
+                activeDocStringSeparator = separator;
+                indentToRemove = token.line.indent();
+            } else {
+                activeDocStringSeparator = null;
+                indentToRemove = 0;
+            }
+
+            setTokenMatched(token, Parser.TokenType.DocStringSeparator, contentType, null, null, null);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean match_StepLine(Token token) {
+        List<String> keywords = currentDialect.getStepKeywords();
+        for (String keyword : keywords) {
+            if (token.line.startsWith(keyword)) {
+                String stepText = token.line.getRestTrimmed(keyword.length());
+                setTokenMatched(token, Parser.TokenType.StepLine, stepText, keyword, null, null);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean match_TableRow(Token token) {
+        if (token.line.startsWith(GherkinLanguageConstants.TABLE_CELL_SEPARATOR)) {
+            setTokenMatched(token, Parser.TokenType.TableRow, null, null, null, token.line.getTableCells());
+            return true;
+        }
+        return false;
+    }
+}

--- a/java/src/main/java/gherkin/IGherkinLine.java
+++ b/java/src/main/java/gherkin/IGherkinLine.java
@@ -3,13 +3,13 @@ package gherkin;
 import java.util.List;
 
 public interface IGherkinLine {
-    public Integer indent();
+    Integer indent();
 
-    public void detach();
+    void detach();
 
-    public String getLineText(int indentToRemove);
+    String getLineText(int indentToRemove);
 
-    public boolean isEmpty();
+    boolean isEmpty();
 
     boolean startsWith(String prefix);
 

--- a/java/src/main/java/gherkin/MarkdownTokenMatcher.java
+++ b/java/src/main/java/gherkin/MarkdownTokenMatcher.java
@@ -1,0 +1,97 @@
+package gherkin;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class MarkdownTokenMatcher extends TokenMatcher {
+
+    public static final Pattern FEATURE_PATTERN = Pattern.compile("^(#\\s*)([^#].*)");
+    public static final Pattern SCENARIO_PATTERN = Pattern.compile("^(##\\s*)([^#].*)");
+    public static final Pattern STEP_PATTERN = Pattern.compile("^(\\*\\s*)([^\\*].*)");
+
+    @Override
+    public boolean match_Comment(Token token) {
+        return false; // We don't support comments in Markdown
+    }
+
+    @Override
+    public boolean match_TagLine(Token token) {
+        // TODO
+        return false;
+    }
+
+    @Override
+    public boolean match_FeatureLine(Token token) {
+        Matcher matcher = FEATURE_PATTERN.matcher(token.line.getLineText(0));
+        if(matcher.matches()) {
+            String keyword = matcher.group(1);
+            String text = matcher.group(2);
+            setTokenMatched(token, Parser.TokenType.FeatureLine, text, keyword, 0, null);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean match_BackgroundLine(Token token) {
+        // We don't support Background in Markdown, at least not yet.
+        // Maybe we could implement it using italics:
+        // ## _This is a background_
+        return false;
+    }
+
+    @Override
+    public boolean match_ScenarioLine(Token token) {
+        Matcher matcher = SCENARIO_PATTERN.matcher(token.line.getLineText(0));
+        if(matcher.matches()) {
+            String keyword = matcher.group(1);
+            String text = matcher.group(2);
+            setTokenMatched(token, Parser.TokenType.ScenarioLine, text, keyword, 0, null);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean match_ScenarioOutlineLine(Token token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean match_ExamplesLine(Token token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean match_StepLine(Token token) {
+        Matcher matcher = STEP_PATTERN.matcher(token.line.getLineText(0));
+        if(matcher.matches()) {
+            String keyword = matcher.group(1);
+            String text = matcher.group(2);
+            setTokenMatched(token, Parser.TokenType.StepLine, text, keyword, 0, null);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean match_DocStringSeparator(Token token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean match_TableRow(Token token) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean match_Language(Token token) {
+        // TODO
+        return false;
+    }
+
+    @Override
+    public boolean match_Other(Token token) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/java/src/main/java/gherkin/Parser.java
+++ b/java/src/main/java/gherkin/Parser.java
@@ -34,10 +34,6 @@ public class Parser<T> {
         Language,
         Other,
         ;
-
-        public static TokenType cast(RuleType ruleType) {
-            return TokenType.values()[ruleType.ordinal()];
-        }
     }
 
     public enum RuleType {
@@ -104,19 +100,19 @@ public class Parser<T> {
         }
     }
 
-    public T parse(String source) {
-        return parse(new StringReader(source));
+    public T parse(String source, ITokenMatcher tokenMatcher) {
+        return parse(new StringReader(source), tokenMatcher);
     }
 
-    public T parse(Reader source) {
+    public T parse(Reader source, ITokenMatcher tokenMatcher) {
         AstBuilder<T> builder = new AstBuilder();
-        return parse(source, builder);
+        return parse(source, builder, tokenMatcher);
     }
 
-    public T parse(Reader source, IAstBuilder<T> builder) {
+    public T parse(Reader source, IAstBuilder<T> builder, ITokenMatcher tokenMatcher) {
         ParserContext context = new ParserContext(
                 new TokenScanner(source),
-                new TokenMatcher(),
+                tokenMatcher,
                 builder,
                 new LinkedList<Token>(),
                 new ArrayList<ParserException>()
@@ -125,16 +121,14 @@ public class Parser<T> {
         startRule(context, RuleType.Feature);
         int state = 0;
         Token token;
-        do
-        {
+        do {
             token = readToken(context);
             state = matchToken(state, token, context);
-        } while(!token.isEOF());
+        } while (!token.isEOF());
 
         endRule(context, RuleType.Feature);
 
-        if (context.errors.size() > 0)
-        {
+        if (context.errors.size() > 0) {
             throw new ParserException.CompositeParserException(context.errors);
         }
 

--- a/java/src/main/java/gherkin/TokenMatcher.java
+++ b/java/src/main/java/gherkin/TokenMatcher.java
@@ -3,27 +3,13 @@ package gherkin;
 import gherkin.ast.Location;
 
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static gherkin.Parser.ITokenMatcher;
 import static gherkin.Parser.TokenType;
 
-public class TokenMatcher implements ITokenMatcher {
-    private static final Pattern LANGUAGE_PATTERN = Pattern.compile("^\\s*#\\s*language\\s*:\\s*([a-zA-Z\\-_]+)\\s*$");
-    private final IGherkinDialectProvider dialectProvider;
-    private GherkinDialect currentDialect;
-    private String activeDocStringSeparator = null;
-    private int indentToRemove = 0;
-
-    public TokenMatcher(IGherkinDialectProvider dialectProvider) {
-        this.dialectProvider = dialectProvider;
-        currentDialect = dialectProvider.getDefaultDialect();
-    }
-
-    public TokenMatcher() {
-        this(new GherkinDialectProvider());
-    }
+public abstract class TokenMatcher implements ITokenMatcher {
+    protected final IGherkinDialectProvider dialectProvider = new GherkinDialectProvider();
+    protected GherkinDialect currentDialect = dialectProvider.getDefaultDialect();
 
     public GherkinDialect getCurrentDialect() {
         return currentDialect;
@@ -40,6 +26,16 @@ public class TokenMatcher implements ITokenMatcher {
     }
 
     @Override
+    public boolean match_Empty(Token token) {
+        if (token.line.isEmpty()) {
+            setTokenMatched(token, Parser.TokenType.Empty, null, null, null, null);
+            return true;
+        }
+        return false;
+    }
+
+
+    @Override
     public boolean match_EOF(Token token) {
         if (token.isEOF()) {
             setTokenMatched(token, TokenType.EOF, null, null, null, null);
@@ -48,137 +44,4 @@ public class TokenMatcher implements ITokenMatcher {
         return false;
     }
 
-    @Override
-    public boolean match_Other(Token token) {
-        String text = token.line.getLineText(indentToRemove); //take the entire line, except removing DocString indents
-        setTokenMatched(token, TokenType.Other, text, null, 0, null);
-        return true;
-    }
-
-    @Override
-    public boolean match_Empty(Token token) {
-        if (token.line.isEmpty()) {
-            setTokenMatched(token, TokenType.Empty, null, null, null, null);
-            return true;
-        }
-        return false;
-    }
-
-    @Override
-    public boolean match_Comment(Token token) {
-        if (token.line.startsWith(GherkinLanguageConstants.COMMENT_PREFIX)) {
-            String text = token.line.getLineText(0); //take the entire line
-            setTokenMatched(token, TokenType.Comment, text, null, 0, null);
-            return true;
-        }
-        return false;
-    }
-
-    @Override
-    public boolean match_Language(Token token) {
-        Matcher matcher = LANGUAGE_PATTERN.matcher(token.line.getLineText(0));
-        if (matcher.matches()) {
-            String language = matcher.group(1);
-            setTokenMatched(token, TokenType.Language, language, null, null, null);
-
-            currentDialect = dialectProvider.getDialect(language, token.location);
-            return true;
-        }
-        return false;
-    }
-
-    @Override
-    public boolean match_TagLine(Token token) {
-        if (token.line.startsWith(GherkinLanguageConstants.TAG_PREFIX)) {
-            setTokenMatched(token, TokenType.TagLine, null, null, null, token.line.getTags());
-            return true;
-        }
-        return false;
-    }
-
-    @Override
-    public boolean match_FeatureLine(Token token) {
-        return matchTitleLine(token, TokenType.FeatureLine, currentDialect.getFeatureKeywords());
-    }
-
-    @Override
-    public boolean match_BackgroundLine(Token token) {
-        return matchTitleLine(token, TokenType.BackgroundLine, currentDialect.getBackgroundKeywords());
-    }
-
-    @Override
-    public boolean match_ScenarioLine(Token token) {
-        return matchTitleLine(token, TokenType.ScenarioLine, currentDialect.getScenarioKeywords());
-    }
-
-    @Override
-    public boolean match_ScenarioOutlineLine(Token token) {
-        return matchTitleLine(token, TokenType.ScenarioOutlineLine, currentDialect.getScenarioOutlineKeywords());
-    }
-
-    @Override
-    public boolean match_ExamplesLine(Token token) {
-        return matchTitleLine(token, TokenType.ExamplesLine, currentDialect.getExamplesKeywords());
-    }
-
-    private boolean matchTitleLine(Token token, TokenType tokenType, List<String> keywords) {
-        for (String keyword : keywords) {
-            if (token.line.startsWithTitleKeyword(keyword)) {
-                String title = token.line.getRestTrimmed(keyword.length() + GherkinLanguageConstants.TITLE_KEYWORD_SEPARATOR.length());
-                setTokenMatched(token, tokenType, title, keyword, null, null);
-                return true;
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public boolean match_DocStringSeparator(Token token) {
-        return activeDocStringSeparator == null
-                // open
-                ? match_DocStringSeparator(token, GherkinLanguageConstants.DOCSTRING_SEPARATOR, true) ||
-                match_DocStringSeparator(token, GherkinLanguageConstants.DOCSTRING_ALTERNATIVE_SEPARATOR, true)
-                // close
-                : match_DocStringSeparator(token, activeDocStringSeparator, false);
-    }
-
-    private boolean match_DocStringSeparator(Token token, String separator, boolean isOpen) {
-        if (token.line.startsWith(separator)) {
-            String contentType = null;
-            if (isOpen) {
-                contentType = token.line.getRestTrimmed(separator.length());
-                activeDocStringSeparator = separator;
-                indentToRemove = token.line.indent();
-            } else {
-                activeDocStringSeparator = null;
-                indentToRemove = 0;
-            }
-
-            setTokenMatched(token, TokenType.DocStringSeparator, contentType, null, null, null);
-            return true;
-        }
-        return false;
-    }
-
-    @Override
-    public boolean match_StepLine(Token token) {
-        List<String> keywords = currentDialect.getStepKeywords();
-        for (String keyword : keywords) {
-            if (token.line.startsWith(keyword)) {
-                String stepText = token.line.getRestTrimmed(keyword.length());
-                setTokenMatched(token, TokenType.StepLine, stepText, keyword, null, null);
-                return true;
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public boolean match_TableRow(Token token) {
-        if (token.line.startsWith(GherkinLanguageConstants.TABLE_CELL_SEPARATOR)) {
-            setTokenMatched(token, TokenType.TableRow, null, null, null, token.line.getTableCells());
-            return true;
-        }
-        return false;
-    }
 }

--- a/java/src/main/java/gherkin/TokenMatcherFactory.java
+++ b/java/src/main/java/gherkin/TokenMatcherFactory.java
@@ -1,0 +1,28 @@
+package gherkin;
+
+public class TokenMatcherFactory {
+    static Parser.ITokenMatcher getTokenMatcher(String fileName) {
+        String ext = getFileExtension(fileName);
+        switch (ext) {
+            case "feature":
+                return new GherkinTokenMatcher();
+            case "markdown":
+            case "md":
+                return new MarkdownTokenMatcher();
+            default:
+                throw new ParserException("Don't know how to parse " + fileName);
+        }
+    }
+
+    private static String getFileExtension(String fileName) {
+        String extension = "";
+
+        int i = fileName.lastIndexOf('.');
+        int p = Math.max(fileName.lastIndexOf('/'), fileName.lastIndexOf('\\'));
+
+        if (i > p) {
+            extension = fileName.substring(i + 1);
+        }
+        return extension;
+    }
+}

--- a/java/src/main/java/gherkin/TokenScanner.java
+++ b/java/src/main/java/gherkin/TokenScanner.java
@@ -25,7 +25,7 @@ public class TokenScanner implements Parser.ITokenScanner {
         try {
             String line = reader.readLine();
             Location location = new Location(++lineNumber, 0);
-            return line == null ? new Token(null, location) : new Token(new GherkinLine(line, lineNumber), location);
+            return line == null ? new Token(null, location) : new Token(new GherkinLine(line), location);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/java/src/main/java/gherkin/html/HtmlAnnotator.java
+++ b/java/src/main/java/gherkin/html/HtmlAnnotator.java
@@ -1,0 +1,34 @@
+package gherkin.html;
+
+import pickles.Pickle;
+import pickles.PickleStep;
+
+import java.util.List;
+
+/**
+ * A very simple HTML processor that annotates li elements with
+ * a data-source-line attribute, pointing to the line number in the
+ * original source.
+ *
+ * This can be used to annotate HTML produced from Markdown, but also
+ * from plain Gherkin (if someone were to write a Gherkin2HTML renderer).
+ */
+public class HtmlAnnotator {
+    public String annotate(String html, List<Pickle> pickles) {
+        String[] lines = html.split("\n");
+        int lineNumber = 0;
+
+        for (Pickle pickle : pickles) {
+            for (PickleStep pickleStep : pickle.getSteps()) {
+                String text = pickleStep.getText();
+                int pickleLineNumber = pickleStep.getSource().get(0).getLine();
+
+                for (int l = lineNumber; l < lines.length; l++) {
+                    lines[l] = lines[l].replaceAll("<li>(" + text + ")</li>", "<li data-source-line=\"" + pickleLineNumber + "\">$1</li>");
+                }
+            }
+        }
+
+        return String.join("\n", lines);
+    }
+}

--- a/java/src/test/java/gherkin/GherkinLineTest.java
+++ b/java/src/test/java/gherkin/GherkinLineTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertEquals;
 public class GherkinLineTest {
     @Test
     public void finds_tags() {
-        GherkinLine gherkinLine = new GherkinLine("    @this @is  @atag  ", 0);
+        GherkinLine gherkinLine = new GherkinLine("    @this @is  @atag  ");
         List<GherkinLineSpan> gherkinLineSpans = gherkinLine.getTags();
 
         assertEquals(asList(

--- a/java/src/test/java/gherkin/compiler/CompilerTest.java
+++ b/java/src/test/java/gherkin/compiler/CompilerTest.java
@@ -1,5 +1,6 @@
 package gherkin.compiler;
 
+import gherkin.GherkinTokenMatcher;
 import gherkin.Parser;
 import gherkin.ast.Feature;
 import gherkin.deps.com.google.gson.Gson;
@@ -20,7 +21,7 @@ public class CompilerTest {
         List<Pickle> pickles = compiler.compile(parser.parse("" +
                 "Feature: f\n" +
                 "  Scenario: s\n" +
-                "    Given passing\n"));
+                "    Given passing\n", new GherkinTokenMatcher()));
 
         System.out.println(gson.toJson(pickles));
     }
@@ -31,7 +32,7 @@ public class CompilerTest {
                 "Feature: f\n" +
                 "  Scenario: s\n" +
                 "    Given passing\n" +
-                "      |x|\n"));
+                "      |x|\n", new GherkinTokenMatcher()));
 
         System.out.println(gson.toJson(pickles));
     }
@@ -47,7 +48,7 @@ public class CompilerTest {
                 "    Given b\n" +
                 "    \n" +
                 "  Scenario:\n" +
-                "    Given c\n"));
+                "    Given c\n", new GherkinTokenMatcher()));
 
         System.out.println(gson.toJson(pickles));
     }
@@ -62,7 +63,7 @@ public class CompilerTest {
                 "\n" +
                 "    Examples: \n" +
                 "      | what       |\n" +
-                "      | minimalism |\n"));
+                "      | minimalism |\n", new GherkinTokenMatcher()));
 
         System.out.println(gson.toJson(pickles));
     }
@@ -82,7 +83,7 @@ public class CompilerTest {
                 "\n" +
                 "    Examples: \n" +
                 "      | what       |\n" +
-                "      | minimalism |\n"));
+                "      | minimalism |\n", new GherkinTokenMatcher()));
 
         System.out.println(gson.toJson(pickles));
     }
@@ -99,7 +100,7 @@ public class CompilerTest {
                 "\n" +
                 "    Examples: \n" +
                 "      | what       |\n" +
-                "      | minimalism |\n"));
+                "      | minimalism |\n", new GherkinTokenMatcher()));
 
         System.out.println(gson.toJson(pickles));
     }

--- a/java/src/test/java/gherkin/html/HtmlAnnotatorTest.java
+++ b/java/src/test/java/gherkin/html/HtmlAnnotatorTest.java
@@ -5,7 +5,6 @@ import gherkin.MarkdownTokenMatcher;
 import gherkin.Parser;
 import gherkin.ast.Feature;
 import gherkin.compiler.Compiler;
-import gherkin.html.HtmlAnnotator;
 import org.junit.Test;
 import pickles.Pickle;
 
@@ -18,7 +17,7 @@ public class HtmlAnnotatorTest {
     private final gherkin.compiler.Compiler compiler = new Compiler();
 
     @Test
-    public void inserts_data_attributes_from_ast() {
+    public void inserts_data_attributes_from_pickles() {
         String markdown = "" +
                 "# Minimal\n" +
                 "\n" +

--- a/java/src/test/java/gherkin/html/HtmlAnnotatorTest.java
+++ b/java/src/test/java/gherkin/html/HtmlAnnotatorTest.java
@@ -1,0 +1,41 @@
+package gherkin.html;
+
+import com.github.rjeschke.txtmark.Processor;
+import gherkin.MarkdownTokenMatcher;
+import gherkin.Parser;
+import gherkin.ast.Feature;
+import gherkin.compiler.Compiler;
+import gherkin.html.HtmlAnnotator;
+import org.junit.Test;
+import pickles.Pickle;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class HtmlAnnotatorTest {
+    private final Parser<Feature> parser = new Parser<>();
+    private final gherkin.compiler.Compiler compiler = new Compiler();
+
+    @Test
+    public void inserts_data_attributes_from_ast() {
+        String markdown = "" +
+                "# Minimal\n" +
+                "\n" +
+                "## minimalistic\n" +
+                "* the minimalism\n";
+        Feature feature = parser.parse(markdown, new MarkdownTokenMatcher());
+        List<Pickle> pickles = compiler.compile(feature);
+
+        String html = Processor.process(markdown);
+        HtmlAnnotator htmlAnnotator = new HtmlAnnotator();
+        String annotatedHtml = htmlAnnotator.annotate(html, pickles);
+        assertEquals("" +
+                        "<h1>Minimal</h1>\n" +
+                        "<h2>minimalistic</h2>\n" +
+                        "<ul>\n" +
+                        "<li data-source-line=\"4\">the minimalism</li>\n" +
+                        "</ul>",
+                annotatedHtml);
+    }
+}

--- a/testdata/good/minimal.md
+++ b/testdata/good/minimal.md
@@ -1,0 +1,4 @@
+# Minimal
+
+## minimalistic
+* the minimalism


### PR DESCRIPTION
I've wanted Cucumber to support Markdown as an alternative syntax to Gherkin for a while. I think it could be beneficial in several areas:

* Ability to embed images alongside scenarios (UI mockups, various sketches and diagrams)
* Markdown has a lot of mindshare

This PR currently has a start of an implementation. It's surprisingly easy to add thanks to the modular architecture - just a new `TokenMatcher` implementation!

There aren't any automated tests yet, but there is a manual one:

```
mvn compile && bin/gherkin-generate-ast ../testdata/good/minimal.md | jq "."
```

Some thoughts about reporting results from Cucumber if we go forward with this. Each markdown documents would get rendered to a HTML file in a reports directory. Results would be written as a JavaScript file, appended into the same HTML file at the end. This JavaScript would modify the DOM: 

* Results: add css classes for status (success/failed/pending/undefined/skipped)
* Stack traces: add dom nodes when a step fails
* Attachments/embedded data: add `<img>` tags

In order to do this, the HTML nodes must have information about line number. This can be added when the Markdown is rendered (before scenarios run). We'd use an existing Markdown processor and post-process the generated HTML by scanning both the markdown source and the generated HTML - should be fairly easy.

I'm excited about this!