### PR TITLE
Ruby: One cell to little when no newline after example table

### DIFF
--- a/ruby/lib/gherkin3/gherkin_line.rb
+++ b/ruby/lib/gherkin3/gherkin_line.rb
@@ -36,7 +36,11 @@ module Gherkin3
     def table_cells
       column = @indent + 1
       items = @trimmed_line_text.split('|')
-      items = items[1..-2] # Skip space before and after outer |
+      if @trimmed_line_text[-1] == '|'
+        items = items[1..-1] # There is no space after last |, only skip space before first |
+      else
+        items = items[1..-2] # Skip space before and after outer |
+      end
       items.map do |item|
         cell_indent = item.length - item.lstrip.length + 1
         span = Span.new(column + cell_indent, item.strip)

--- a/testdata/good/scenario_outline_no_newline.feature
+++ b/testdata/good/scenario_outline_no_newline.feature
@@ -1,0 +1,8 @@
+Feature: Minimal Scenario Outline
+
+Scenario Outline: minimalistic
+    Given the <what>
+
+Examples:
+  | what       |
+  | minimalism |

--- a/testdata/good/scenario_outline_no_newline.feature.ast.json
+++ b/testdata/good/scenario_outline_no_newline.feature.ast.json
@@ -1,0 +1,83 @@
+{
+  "comments": [],
+  "keyword": "Feature",
+  "language": "en",
+  "location": {
+    "column": 1,
+    "line": 1
+  },
+  "name": "Minimal Scenario Outline",
+  "scenarioDefinitions": [
+    {
+      "examples": [
+        {
+          "keyword": "Examples",
+          "location": {
+            "column": 1,
+            "line": 6
+          },
+          "name": "",
+          "tableBody": [
+            {
+              "cells": [
+                {
+                  "location": {
+                    "column": 5,
+                    "line": 8
+                  },
+                  "type": "TableCell",
+                  "value": "minimalism"
+                }
+              ],
+              "location": {
+                "column": 3,
+                "line": 8
+              },
+              "type": "TableRow"
+            }
+          ],
+          "tableHeader": {
+            "cells": [
+              {
+                "location": {
+                  "column": 5,
+                  "line": 7
+                },
+                "type": "TableCell",
+                "value": "what"
+              }
+            ],
+            "location": {
+              "column": 3,
+              "line": 7
+            },
+            "type": "TableRow"
+          },
+          "tags": [],
+          "type": "Examples"
+        }
+      ],
+      "keyword": "Scenario Outline",
+      "location": {
+        "column": 1,
+        "line": 3
+      },
+      "name": "minimalistic",
+      "steps": [
+        {
+          "keyword": "Given ",
+          "location": {
+            "column": 5,
+            "line": 4
+          },
+          "text": "the <what>",
+          "type": "Step"
+        }
+      ],
+      "tags": [],
+      "type": "ScenarioOutline"
+    }
+  ],
+  "tags": [],
+  "type": "Feature"
+}

--- a/testdata/good/scenario_outline_no_newline.feature.pickles.json
+++ b/testdata/good/scenario_outline_no_newline.feature.pickles.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "Scenario: minimalistic",
+    "source": [
+      {
+        "column": 1,
+        "line": 3
+      }
+    ],
+    "steps": [
+      {
+        "source": [
+          {
+            "column": 5,
+            "line": 4
+          },
+          {
+            "column": 3,
+            "line": 8
+          }
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "tags": []
+  }
+]

--- a/testdata/good/scenario_outline_no_newline.feature.tokens
+++ b/testdata/good/scenario_outline_no_newline.feature.tokens
@@ -1,0 +1,9 @@
+(1:1)FeatureLine:Feature/Minimal Scenario Outline/
+(2:1)Empty://
+(3:1)ScenarioOutlineLine:Scenario Outline/minimalistic/
+(4:5)StepLine:Given /the <what>/
+(5:1)Empty://
+(6:1)ExamplesLine:Examples//
+(7:3)TableRow://5:what
+(8:3)TableRow://5:minimalism
+EOF


### PR DESCRIPTION
If there is not blank or newline after the last cell of the last row in the example table, then the last parsed table row will have one cell to little, when using the ruby version of Gherkin3. This in turn causes a inconsistent cell count exception.

Several of the feature files for Cucumber contain this type of example tables from using the following constructs in the feature files:
```
 Given a file named "features/f.feature" with:
    """
    <snip>
      Examples:
      | Value           |
      | Also Irrelevant |
    """
```
