### PR TITLE
Fix #75: Use “Keep A CHANGELOG” format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,48 @@
-# Git master
+# CHANGE LOG
 
-* (Python) [#74](https://github.com/cucumber/gherkin3/pull/74) Close file descriptors
-* (Python) [#72](https://github.com/cucumber/gherkin3/pull/72) Use new-style classes
-* (JavaScript) Default argument for `Parser(builder)` and `Parser.parse(scanner, matcher)`
+All notable changes to this project will be documented in this file.
 
-# 3.1.0 (2015-08-16)
+This project adheres to [Semantic Versioning](http://semver.org).
 
-* (Java) Maven artifact `groupId` changed to `io.cucumber` (was previously `info.cukes`)
-* (JavaScript) remove tea-error dependency
-* (.NET) [#57](https://github.com/cucumber/gherkin3/issues/57), [#58](https://github.com/cucumber/gherkin3/issues/58) Release Nuget package
-* (All) [#62](https://github.com/cucumber/gherkin3/issues/62) Cannot parse multiple times
-* (Python) [#63](https://github.com/cucumber/gherkin3/issues/63) gherkin-languages.json not packaged
 
-# 3.0.0
+
+## [Unreleased][unreleased]
+
+### Added
+* (JavaScript)  Default arguments for `Parser(builder)` and `Parser.parse(scanner, matcher)` 
+
+### Changed
+* (Java)        Improvements to the build process
+* (JavaScript)  It's now possible to pass a string directly to `Parser.parse()`
+* (Python)      [#72](https://github.com/cucumber/gherkin3/pull/72) Use new-style classes
+
+### Fixed
+* (Python)      [#74](https://github.com/cucumber/gherkin3/pull/74) File descriptors are now excplicitly closed
+
+
+
+## [3.1.0] - 2015-08-16
+
+### Removed
+* (JavaScript) Remove `tea-error` dependency
+
+### Added
+* (.NET) [#57](https://github.com/cucumber/gherkin3/issues/57)
+     and [#58](https://github.com/cucumber/gherkin3/issues/58) Release Nuget package
+
+### Changed
+* (Java) Maven `groupId` artifact changed from `info.cukes` to `io.cucumber`
+
+### Fixed
+* (All) [#62](https://github.com/cucumber/gherkin3/issues/62) Multiple calls to `parse()` cannot use the same instance of `AstBuilder` 
+* (Python) [#63](https://github.com/cucumber/gherkin3/issues/63) `gherkin-languages.json` not packaged
+
+
+
+## 3.0.0 - 2015-07-16
 
 * First release
+
+
+[unreleased]: https://github.com/cucumber/gherkin3/compare/v3.1.0...HEAD
+[3.1.0]:      https://github.com/cucumber/gherkin3/compare/v3.0.0...v3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ This project adheres to [Semantic Versioning](http://semver.org).
 ### Changed
 * (Java)        Improvements to the build process
 * (JavaScript)  It's now possible to pass a string directly to `Parser.parse()`
-* (Python)      [#72](https://github.com/cucumber/gherkin3/pull/72) Use new-style classes
+* (Python)      Use new-style classes 
+  ([#72](https://github.com/cucumber/gherkin3/pull/72))
 
 ### Fixed
-* (Python)      [#74](https://github.com/cucumber/gherkin3/pull/74) File descriptors are now excplicitly closed
+* (Python) File descriptors are now excplicitly closed
+  ([#74](https://github.com/cucumber/gherkin3/pull/74))
 
 
 
@@ -27,15 +29,18 @@ This project adheres to [Semantic Versioning](http://semver.org).
 * (JavaScript) Remove `tea-error` dependency
 
 ### Added
-* (.NET) [#57](https://github.com/cucumber/gherkin3/issues/57)
-     and [#58](https://github.com/cucumber/gherkin3/issues/58) Release Nuget package
+* (.NET) Release Nuget package
+  ([#57](https://github.com/cucumber/gherkin3/issues/57),
+   [#58](https://github.com/cucumber/gherkin3/issues/58))
 
 ### Changed
 * (Java) Maven `groupId` artifact changed from `info.cukes` to `io.cucumber`
 
 ### Fixed
-* (All) [#62](https://github.com/cucumber/gherkin3/issues/62) Multiple calls to `parse()` cannot use the same instance of `AstBuilder` 
-* (Python) [#63](https://github.com/cucumber/gherkin3/issues/63) `gherkin-languages.json` not packaged
+* (All) Multiple calls to `parse()` cannot use the same instance of `AstBuilder`
+  ([#62](https://github.com/cucumber/gherkin3/issues/62))
+* (Python) `gherkin-languages.json` not packaged
+  ([#63](https://github.com/cucumber/gherkin3/issues/63))
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org).
 
+This document is formatted according to the principles of [Keep A CHANGELOG](http://keepachangelog.com).
 
+----
 
 ## [Unreleased][unreleased]
 


### PR DESCRIPTION
I moved the issue links after the summaries, because it:

- …**puts the summary first,** which is the primary thing of interest to the reader; and, it
- …**makes it easier for humans that edit the file,** because you can put each link on a line below the change, which makes it much easier to read as plain text (in keeping with the spirit of Markdown)