### PR TITLE
Add short description comments for TokenScanner

### DIFF
--- a/dotnet/Gherkin/TokenScanner.cs
+++ b/dotnet/Gherkin/TokenScanner.cs
@@ -5,6 +5,16 @@ using Gherkin.Ast;
 
 namespace Gherkin
 {
+    /// <summary>
+    /// The scanner reads a gherkin doc (typically read from a .feature file) and creates a token 
+    /// for each line. 
+    /// 
+    /// The tokens are passed to the parser, which outputs an AST (Abstract Syntax Tree).
+    /// 
+    /// If the scanner sees a `#` language header, it will reconfigure itself dynamically to look 
+    /// for  Gherkin keywords for the associated language. The keywords are defined in 
+    /// gherkin-languages.json.
+    /// </summary>
     public class TokenScanner : ITokenScanner
     {
         protected int lineNumber = 0;

--- a/go/gherkin3.go
+++ b/go/gherkin3.go
@@ -12,6 +12,13 @@ type Parser interface {
 	Parse(s Scanner, m Matcher) (err error)
 }
 
+/* 
+The scanner reads a gherkin doc (typically read from a .feature file) and creates a token for 
+each line. The tokens are passed to the parser, which outputs an AST (Abstract Syntax Tree).
+
+If the scanner sees a # language header, it will reconfigure itself dynamically to look for 
+Gherkin keywords for the associated language. The keywords are defined in gherkin-languages.json.
+*/
 type Scanner interface {
 	Scan() (line *Line, atEof bool, err error)
 }

--- a/java/src/main/java/gherkin/TokenScanner.java
+++ b/java/src/main/java/gherkin/TokenScanner.java
@@ -7,6 +7,15 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 
+/**
+ * <p>
+ * The scanner reads a gherkin doc (typically read from a .feature file) and creates a token 
+ * for each line. The tokens are passed to the parser, which outputs an AST (Abstract Syntax Tree).</p>
+ *
+ * <p>
+ * If the scanner sees a # language header, it will reconfigure itself dynamically to look for 
+ * Gherkin keywords for the associated language. The keywords are defined in gherkin-languages.json.</p>
+ */
 public class TokenScanner implements Parser.ITokenScanner {
 
     private final BufferedReader reader;

--- a/javascript/lib/gherkin/token_scanner.js
+++ b/javascript/lib/gherkin/token_scanner.js
@@ -1,6 +1,13 @@
 var Token = require('./token');
 var GherkinLine = require('./gherkin_line');
 
+/**
+ * The scanner reads a gherkin doc (typically read from a .feature file) and creates a token for each line. 
+ * The tokens are passed to the parser, which outputs an AST (Abstract Syntax Tree).
+ * 
+ * If the scanner sees a `#` language header, it will reconfigure itself dynamically to look for 
+ * Gherkin keywords for the associated language. The keywords are defined in gherkin-languages.json.
+ */
 module.exports = function TokenScanner(source) {
   var lines = source.split(/\r?\n/);
   if(lines.length > 0 && lines[lines.length-1].trim() == '') {

--- a/python/gherkin3/token_scanner.py
+++ b/python/gherkin3/token_scanner.py
@@ -10,6 +10,17 @@ except ImportError:
 
 
 class TokenScanner(object):
+    """
+    The scanner reads a gherkin doc (typically read from a `.feature` file) and creates a token for 
+    each line. 
+    
+    The tokens are passed to the parser, which outputs an AST (Abstract Syntax Tree).
+    
+    If the scanner sees a `#` language header, it will reconfigure itself dynamically to look for 
+    Gherkin keywords for the associated language. The keywords are defined in 
+    :file:`gherkin-languages.json`.
+    """
+    
     def __init__(self, path_or_str):
         if isinstance(path_or_str, str):
             if os.path.exists(path_or_str):

--- a/ruby/lib/gherkin3/token_scanner.rb
+++ b/ruby/lib/gherkin3/token_scanner.rb
@@ -2,6 +2,14 @@ require_relative 'token'
 require_relative 'gherkin_line'
 
 module Gherkin3
+  
+  # The scanner reads a gherkin doc (typically read from a .feature file) and 
+  # creates a token for line. The tokens are passed to the parser, which outputs 
+  # an AST (Abstract Syntax Tree).
+  #
+  # If the scanner sees a # language header, it will reconfigure itself dynamically 
+  # to look for Gherkin keywords for the associated language. The keywords are defined 
+  # in gherkin-languages.json.
   class TokenScanner
 
     def initialize(source_or_path_or_io)


### PR DESCRIPTION
* The description is taken from the README.md
* I looked up the basic rules for “documentation comments” for each language, in order to provide (minimal but functional) support for documentation generators