### PR TITLE
Add short description comments for AstBuilder

### DIFF
--- a/dotnet/Gherkin/AstBuilder.cs
+++ b/dotnet/Gherkin/AstBuilder.cs
@@ -5,6 +5,21 @@ using Gherkin.Ast;
 
 namespace Gherkin
 {
+    /// <summary>
+    /// This class is used by the Parser to build an AST (Abstract Syntax Tree), which is 
+    /// composed of Nodes.
+    /// 
+    /// The implementation is simple objects without behaviour, only data. 
+    /// The AST must have a JSON representation (this is used for testing).
+    /// 
+    /// Every Node has a Location, which describes the line number and column number in 
+    /// the input file. These numbers are 1-indexed.
+    /// 
+    /// All fields on nodes are strings (except for `Location.line` and `Location.column`).
+    /// 
+    /// In the JSON representation, each Node also has a `type` property with the name of 
+    /// the node type.
+    /// </summary>
     public class AstBuilder<T> : IAstBuilder<T>
     {
         private readonly Stack<AstNode> stack = new Stack<AstNode>();

--- a/go/astbuilder.go
+++ b/go/astbuilder.go
@@ -4,6 +4,21 @@ import (
 	"strings"
 )
 
+/*
+The AstBuilder is used by the Parser to build an AST (Abstract Syntax Tree), which is 
+composed of Nodes.
+
+The implementation is simple objects without behaviour, only data. 
+The AST must have a JSON representation (this is used for testing).
+
+Every Node has a Location, which describes the line number and column number in 
+the input file. These numbers are 1-indexed.
+
+All fields on nodes are strings (except for `Location.line` and `Location.column`).
+
+In the JSON representation, each Node also has a `type` property with the name of 
+the node type.
+*/
 type AstBuilder interface {
 	Builder
 	GetFeature() *Feature

--- a/java/src/main/java/gherkin/AstBuilder.java
+++ b/java/src/main/java/gherkin/AstBuilder.java
@@ -26,6 +26,27 @@ import static gherkin.Parser.RuleType;
 import static gherkin.Parser.TokenType;
 import static gherkin.StringUtils.join;
 
+
+/**
+ * <p>
+ * This class is used by the Parser to build an AST (Abstract Syntax Tree), which is 
+ * composed of Nodes.</p>
+ * 
+ * <p>
+ * The implementation is simple objects without behaviour, only data. 
+ * The AST must have a JSON representation (this is used for testing).</p>
+ * 
+ * <p>
+ * Every Node has a Location, which describes the line number and column number in 
+ * the input file. These numbers are 1-indexed.</p>
+ * 
+ * <p>
+ * All fields on nodes are strings (except for `Location.line` and `Location.column`).</p>
+ * 
+ * <p>
+ * In the JSON representation, each Node also has a `type` property with the name of 
+ * the node type.</p>
+ */
 public class AstBuilder implements Builder<Feature> {
     private Deque<AstNode> stack;
     private List<Comment> comments;

--- a/javascript/lib/gherkin/ast_builder.js
+++ b/javascript/lib/gherkin/ast_builder.js
@@ -1,6 +1,21 @@
 var AstNode = require('./ast_node');
 var Errors = require('./errors');
 
+/**
+ * This class is used by the Parser to build an AST (Abstract Syntax Tree), which is 
+ * composed of Nodes.
+ * 
+ * The implementation is simple objects without behaviour, only data. 
+ * The AST must have a JSON representation (this is used for testing).
+ * 
+ * Every Node has a Location, which describes the line number and column number in 
+ * the input file. These numbers are 1-indexed.
+ * 
+ * All fields on nodes are strings (except for `Location.line` and `Location.column`).
+ * 
+ * In the JSON representation, each Node also has a `type` property with the name of 
+ * the node type.
+ */
 module.exports = function AstBuilder () {
 
   var stack = [new AstNode('None')];

--- a/python/gherkin3/ast_builder.py
+++ b/python/gherkin3/ast_builder.py
@@ -3,6 +3,21 @@ from .errors import AstBuilderException
 
 
 class AstBuilder(object):
+    """
+    This class is used by the Parser to build an AST (Abstract Syntax Tree), which is 
+    composed of Nodes.
+
+    The implementation is simple objects without behaviour, only data. 
+    The AST must have a JSON representation (this is used for testing).
+
+    Every Node has a Location, which describes the line number and column number in 
+    the input file. These numbers are 1-indexed.
+
+    All fields on nodes are strings (except for `Location.line` and `Location.column`).
+
+    In the JSON representation, each Node also has a `type` property with the name of 
+    the node type.
+    """
     def __init__(self):
         self.reset()
 

--- a/ruby/lib/gherkin3/ast_builder.rb
+++ b/ruby/lib/gherkin3/ast_builder.rb
@@ -1,6 +1,20 @@
 require_relative 'ast_node'
 
 module Gherkin3
+  
+  # This class is used by the Parser to build an AST (Abstract Syntax Tree), which is 
+  # composed of Nodes.
+  # 
+  # The implementation is simple objects without behaviour, only data. 
+  # The AST must have a JSON representation (this is used for testing).
+  # 
+  # Every Node has a Location, which describes the line number and column number in 
+  # the input file. These numbers are 1-indexed.
+  # 
+  # All fields on nodes are strings (except for `Location.line` and `Location.column`).
+  # 
+  # In the JSON representation, each Node also has a `type` property with the name of 
+  # the node type.
   class AstBuilder
     def initialize
       reset


### PR DESCRIPTION
* The description is a (slightly modified) bit of text from the README.md
* I looked up the basic rules for “documentation comments” for each language, in order to provide (minimal but functional) support for documentation generators