### PR TITLE
Add docstring comments for AstNode and AstBuilder

### DIFF
--- a/dotnet/Gherkin/AstBuilder.cs
+++ b/dotnet/Gherkin/AstBuilder.cs
@@ -5,6 +5,14 @@ using Gherkin.Ast;
 
 namespace Gherkin
 {
+    /// <summary>
+    /// The AstBuilder (used by the Parser) builds the AST (Abstract Syntax Tree).
+    /// The AST is comprised of AstNode objects (or “nodes”).
+    /// 
+    /// The implementation is simple objects without behaviour, only data. 
+    /// It's up to the implementation to decide whether to use classes or just basic collections, 
+    /// but the AST must have a JSON representation (this is used for testing).
+    /// </summary>
     public class AstBuilder<T> : IAstBuilder<T>
     {
         private readonly Stack<AstNode> stack = new Stack<AstNode>();

--- a/dotnet/Gherkin/AstNode.cs
+++ b/dotnet/Gherkin/AstNode.cs
@@ -4,6 +4,19 @@ using System.Linq;
 
 namespace Gherkin
 {
+    /// <summary>
+    /// Nodes are created by the AstBuilder, and are the building blocks of the AST (Abstract Syntax Tree). 
+    /// Every node has a Location that describes the line number and column number in the input file. 
+    /// These numbers are 1-indexed.
+    /// 
+    /// All fields on nodes are strings (except for Location.line and Location.column).
+    /// 
+    /// The implementation is simple objects without behaviour, only data. 
+    /// It's up to the implementation to decide whether to use classes or just basic collections, 
+    /// but the AST must have a JSON representation (this is used for testing).
+    /// 
+    /// Each node in the JSON representation also has a type property with the name of the node type.
+    /// </summary>
     public class AstNode
     {
         private readonly Dictionary<RuleType, IList<object>> subItems = new Dictionary<RuleType, IList<object>>();

--- a/go/astbuilder.go
+++ b/go/astbuilder.go
@@ -4,6 +4,14 @@ import (
 	"strings"
 )
 
+/*
+The AstBuilder (used by the Parser) builds the AST (Abstract Syntax Tree).
+The AST is comprised of AstNode objects (or “nodes”).
+
+The implementation is simple objects without behaviour, only data. 
+It's up to the implementation to decide whether to use classes or just basic collections, 
+but the AST must have a JSON representation (this is used for testing).
+*/
 type AstBuilder interface {
 	Builder
 	GetFeature() *Feature
@@ -28,6 +36,19 @@ func (t *astBuilder) GetFeature() *Feature {
 	return nil
 }
 
+/*
+Nodes are created by the AstBuilder, and are the building blocks of the AST (Abstract Syntax Tree).
+Every node has a Location that describes the line number and column number in the input file.
+These numbers are 1-indexed.
+
+All fields on nodes are strings (except for Location.line and Location.column).
+
+The implementation is simple objects without behaviour, only data.
+It's up to the implementation to decide whether to use classes or just basic collections,
+but the AST must have a JSON representation (this is used for testing).
+
+Each node in the JSON representation also has a type property with the name of the node type.
+*/
 type astNode struct {
 	ruleType RuleType
 	subNodes map[RuleType][]interface{}

--- a/java/src/main/java/gherkin/AstBuilder.java
+++ b/java/src/main/java/gherkin/AstBuilder.java
@@ -26,6 +26,17 @@ import static gherkin.Parser.RuleType;
 import static gherkin.Parser.TokenType;
 import static gherkin.StringUtils.join;
 
+
+/**
+ * <p>
+ * The <code>AstBuilder</code> (used by the <code>Parser</code>) builds the AST (Abstract Syntax Tree).
+ * The AST is comprised of <code>AstNode</code> objects (or “nodes”).</p>
+ * 
+ * <p>
+ * The implementation is simple objects without behaviour, only data. 
+ * It's up to the implementation to decide whether to use classes or just basic collections, 
+ * but the AST must have a JSON representation (this is used for testing).</p>
+ */
 public class AstBuilder implements Builder<Feature> {
     private Deque<AstNode> stack;
     private List<Comment> comments;

--- a/java/src/main/java/gherkin/AstNode.java
+++ b/java/src/main/java/gherkin/AstNode.java
@@ -9,6 +9,24 @@ import java.util.Map;
 import static gherkin.Parser.RuleType;
 import static gherkin.Parser.TokenType;
 
+
+/**
+ * <p>
+ * Nodes are created by the <code>AstBuilder</code>, and are the building blocks of the AST (Abstract Syntax Tree). 
+ * Every node has a <var>Location</var> that describes the line number and column number in the input file. 
+ * These numbers are 1-indexed.</p>
+ * 
+ * <p>
+ * All fields on nodes are strings (except for <var>Location.line</var> and <var>Location.column</var>).</p>
+ * 
+ * <p>
+ * The implementation is simple objects without behaviour, only data. 
+ * It's up to the implementation to decide whether to use classes or just basic collections, 
+ * but the AST must have a JSON representation (this is used for testing).</p>
+ * 
+ * <p>
+ * Each node in the JSON representation also has a <var>type</var> property with the name of the node type.</p>
+ */
 public class AstNode {
     private final Map<RuleType, List<Object>> subItems = new HashMap<RuleType, List<Object>>();
     public final RuleType ruleType;

--- a/javascript/lib/gherkin/ast_builder.js
+++ b/javascript/lib/gherkin/ast_builder.js
@@ -1,6 +1,14 @@
 var AstNode = require('./ast_node');
 var Errors = require('./errors');
 
+/**
+ * The `AstBuilder` (used by the `Parser`) builds the AST (Abstract Syntax Tree).
+ * The AST is comprised of `AstNode` objects (or “nodes”).
+ * 
+ * The implementation is simple objects without behaviour, only data. 
+ * It's up to the implementation to decide whether to use classes or just basic collections, 
+ * but the AST must have a JSON representation (this is used for testing).
+ */
 module.exports = function AstBuilder () {
 
   var stack = [new AstNode('None')];

--- a/javascript/lib/gherkin/ast_node.js
+++ b/javascript/lib/gherkin/ast_node.js
@@ -1,3 +1,16 @@
+/**
+ * Nodes are created by the `AstBuilder`, and are the building blocks of the AST (Abstract Syntax Tree). 
+ * Every node has a `Location` that describes the line number and column number in the input file. 
+ * These numbers are 1-indexed.
+ * 
+ * All fields on nodes are strings (except for `Location.line` and `Location.column`).
+ * 
+ * The implementation is simple objects without behaviour, only data. 
+ * It's up to the implementation to decide whether to use classes or just basic collections, 
+ * but the AST must have a JSON representation (this is used for testing).
+ * 
+ * Each node in the JSON representation also has a `type` property with the name of the node type.
+ */
 function AstNode (ruleType) {
   this.ruleType = ruleType;
   this._subItems = {};

--- a/python/gherkin3/ast_builder.py
+++ b/python/gherkin3/ast_builder.py
@@ -5,7 +5,7 @@ from .errors import AstBuilderException
 class AstBuilder(object):
     """
     The :class:`AstBuilder` (used by the :class:`Parser`) builds the AST (Abstract Syntax Tree).
-    The AST is comprised of :class:`AstNode` objects (or “nodes”).
+    The AST is comprised of :class:`AstNode` objects (or "nodes").
 
     The implementation is simple objects without behaviour, only data. 
     It's up to the implementation to decide whether to use classes or just basic collections, 

--- a/python/gherkin3/ast_builder.py
+++ b/python/gherkin3/ast_builder.py
@@ -3,6 +3,15 @@ from .errors import AstBuilderException
 
 
 class AstBuilder(object):
+    """
+    The :class:`AstBuilder` (used by the :class:`Parser`) builds the AST (Abstract Syntax Tree).
+    The AST is comprised of :class:`AstNode` objects (or “nodes”).
+
+    The implementation is simple objects without behaviour, only data. 
+    It's up to the implementation to decide whether to use classes or just basic collections, 
+    but the AST must have a JSON representation (this is used for testing).
+    """
+    
     def __init__(self):
         self.reset()
 

--- a/python/gherkin3/ast_node.py
+++ b/python/gherkin3/ast_node.py
@@ -2,7 +2,20 @@ from collections import defaultdict
 
 
 class AstNode(object):
+    """
+    Nodes are created by the :class:`AstBuilder`, and are the building blocks of the AST (Abstract Syntax Tree). 
+    Every node has a `Location` that describes the line number and column number in the input file. 
+    These numbers are 1-indexed.
 
+    All fields on nodes are strings (except for `Location.line` and `Location.column`).
+
+    The implementation is simple objects without behaviour, only data. 
+    It's up to the implementation to decide whether to use classes or just basic collections, 
+    but the AST must have a JSON representation (this is used for testing).
+
+    Each node in the JSON representation also has a `type` property with the name of the node type.
+    """
+    
     def __init__(self, rule_type):
         self.rule_type = rule_type
         self._sub_items = defaultdict(list)

--- a/ruby/lib/gherkin3/ast_builder.rb
+++ b/ruby/lib/gherkin3/ast_builder.rb
@@ -1,6 +1,13 @@
 require_relative 'ast_node'
 
 module Gherkin3
+  
+  # The AstBuilder (used by the Parser) builds the AST (Abstract Syntax Tree).
+  # The AST is comprised of AstNode objects (or “nodes”).
+  #
+  # The implementation is simple objects without behaviour, only data.
+  # It's up to the implementation to decide whether to use classes or just basic collections,
+  # but the AST must have a JSON representation (this is used for testing).
   class AstBuilder
     def initialize
       reset

--- a/ruby/lib/gherkin3/ast_builder.rb
+++ b/ruby/lib/gherkin3/ast_builder.rb
@@ -3,7 +3,7 @@ require_relative 'ast_node'
 module Gherkin3
   
   # The AstBuilder (used by the Parser) builds the AST (Abstract Syntax Tree).
-  # The AST is comprised of AstNode objects (or “nodes”).
+  # The AST is comprised of AstNode objects (or "nodes").
   #
   # The implementation is simple objects without behaviour, only data.
   # It's up to the implementation to decide whether to use classes or just basic collections,

--- a/ruby/lib/gherkin3/ast_node.rb
+++ b/ruby/lib/gherkin3/ast_node.rb
@@ -1,4 +1,16 @@
 module Gherkin3
+  
+  # Nodes are created by the AstBuilder, and are the building blocks of the AST (Abstract Syntax Tree).
+  # Every node has a Location that describes the line number and column number in the input file.
+  # These numbers are 1-indexed.
+  #
+  # All fields on nodes are strings (except for Location.line and Location.column).
+  #
+  # The implementation is simple objects without behaviour, only data.
+  # It's up to the implementation to decide whether to use classes or just basic collections,
+  # but the AST must have a JSON representation (this is used for testing).
+  #
+  # Each node in the JSON representation also has a `type` property with the name of the node type.
   class AstNode
     attr_reader :rule_type
 


### PR DESCRIPTION
* Docstring content inspired by text in README.md
* Each implementation has the appropriate docstring (sometimes with a minimal amount of their preferred flavor of markup)