### PR TITLE
Fix #93 opening dialect file in binary mode.

### DIFF
--- a/python/gherkin3/dialect.py
+++ b/python/gherkin3/dialect.py
@@ -8,7 +8,7 @@ DIALECT_FILE_PATH = os.path.join(
     'gherkin-languages.json'
     )
 
-with io.open(DIALECT_FILE_PATH, 'r') as file:
+with io.open(DIALECT_FILE_PATH, 'rb') as file:
     DIALECTS = json.load(file, encoding='utf-8')
 
 


### PR DESCRIPTION
On Windows, files other than ASCII should be opened with 'b' mode, this includes unicode files.
See https://docs.python.org/2/tutorial/inputoutput.html#reading-and-writing-files