### PR TITLE
Fix Ruby example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ var feature = parser.Parse("Feature: ...");
 ```ruby
 # Ruby
 require 'gherkin3/parser'
+require 'gherkin3/token_scanner'
 parser = Gherkin3::Parser.new
-feature = parser.parse("Feature: ...")
+scanner = Gherkin3::TokenScanner.new("Feature: ...")
+feature = parser.parse(scanner)
 ```
 
 ```javascript


### PR DESCRIPTION
A scanner is required when parsing a feature file.
parser_spec use the same process: https://github.com/cucumber/gherkin3/blob/master/ruby/spec/gherkin3/parser_spec.rb