### PR TITLE
Fix readme for ruby and fix missing require statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ var feature = parser.Parse("Feature: ...");
 ```ruby
 # Ruby
 require 'gherkin3/parser'
+require 'gherkin3/token_scanner'
+
 parser = Gherkin3::Parser.new
-feature = parser.parse("Feature: ...")
+feature = parser.parse(Gherkin3::TokenScanner.new("Feature: ..."))
 ```
 
 ```javascript

--- a/ruby/lib/gherkin3/token_scanner.rb
+++ b/ruby/lib/gherkin3/token_scanner.rb
@@ -1,8 +1,10 @@
 require_relative 'token'
 require_relative 'gherkin_line'
 
+require 'stringio'
+
 module Gherkin3
-  
+
   # The scanner reads a gherkin doc (typically read from a .feature file) and 
   # creates a token for line. The tokens are passed to the parser, which outputs 
   # an AST (Abstract Syntax Tree).


### PR DESCRIPTION
I found some small issues with gherkin3. 

1. The example does not work for ruby - at least not in a C&P-fashion. I changed this. Now ruby users can just start an irb and paste the code there.

2. Furthermore `StringIO` is used, but needs to be loaded first. I added the require statement directly to the class-file of the tokenscanner.