### PR TITLE
Make parser take strings as well

### DIFF
--- a/ruby/.gitignore
+++ b/ruby/.gitignore
@@ -4,3 +4,4 @@ acceptance/
 .built
 .compared
 pkg/
+tmp/

--- a/ruby/.rspec
+++ b/ruby/.rspec
@@ -1,0 +1,1 @@
+ -r aruba/rspec

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,3 +1,13 @@
 [![Build Status](https://secure.travis-ci.org/cucumber/gherkin-ruby.png)](http://travis-ci.org/cucumber/gherkin-ruby)
 
 Gherkin parser/compiler for Ruby. Please see [Gherkin3](https://github.com/cucumber/gherkin3) for details.
+
+## Developers
+
+Some files are generated from the `gherkin-ruby.razor` file. Please run the
+following command to generate the ruby files.
+
+~~~bash
+cd <project_root>/ruby
+bundle exec make
+~~~

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -7,7 +7,7 @@ $:.unshift File.expand_path("../lib", __FILE__)
 
 require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.ruby_opts  = %w[-r./spec/coverage -w]
+  t.ruby_opts  = %w[-r./spec/coverage -w -r aruba/rspec]
   t.rspec_opts = %w[--color]
 end
 

--- a/ruby/gherkin-ruby.razor
+++ b/ruby/gherkin-ruby.razor
@@ -28,6 +28,7 @@
 # This file is generated. Do not edit! Edit gherkin-ruby.razor instead.
 require_relative 'ast_builder'
 require_relative 'token_matcher'
+require_relative 'token_scanner'
 require_relative 'errors'
 
 module Gherkin3
@@ -57,7 +58,9 @@ module Gherkin3
       @@ast_builder = ast_builder
     end
 
-    def parse(token_scanner, token_matcher=TokenMatcher.new)
+    def parse(input, token_matcher=TokenMatcher.new)
+      token_scanner = input.is_a?(TokenScanner) ? input : TokenScanner.new(input)
+
       @@ast_builder.reset
       token_matcher.reset
       context = ParserContext.new(

--- a/ruby/gherkin3.gemspec
+++ b/ruby/gherkin3.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler',   '~> 1.7'
   s.add_development_dependency 'rake',      '~> 10.4'
   s.add_development_dependency 'rspec',     '~> 3.3'
+  s.add_development_dependency 'aruba',     '~> 0.9'
 
   # For coverage reports
   s.add_development_dependency 'coveralls', '~> 0.8'

--- a/ruby/lib/gherkin3/parser.rb
+++ b/ruby/lib/gherkin3/parser.rb
@@ -1,6 +1,7 @@
 # This file is generated. Do not edit! Edit gherkin-ruby.razor instead.
 require_relative 'ast_builder'
 require_relative 'token_matcher'
+require_relative 'token_scanner'
 require_relative 'errors'
 
 module Gherkin3
@@ -63,7 +64,9 @@ module Gherkin3
       @ast_builder = ast_builder
     end
 
-    def parse(token_scanner, token_matcher=TokenMatcher.new)
+    def parse(input, token_matcher=TokenMatcher.new)
+      token_scanner = input.is_a?(TokenScanner) ? input : TokenScanner.new(input)
+
       @ast_builder.reset
       token_matcher.reset
       context = ParserContext.new(

--- a/ruby/lib/gherkin3/scanners/basic_scanner.rb
+++ b/ruby/lib/gherkin3/scanners/basic_scanner.rb
@@ -1,0 +1,25 @@
+require 'gherkin3/token'
+require 'gherkin3/gherkin_line'
+
+module Gherkin3
+  module Scanners
+    class BasicScanner
+      attr_reader :io
+
+      def initialize(*)
+        @line_number = 0
+      end
+
+      def read
+        location = {line: @line_number += 1}
+        if io.nil? || line = io.gets
+          gherkin_line = line ? GherkinLine.new(line, location[:line]) : nil
+          Token.new(gherkin_line, location)
+        else
+          io.close unless io.closed? # ARGF closes the last file after final gets
+          Token.new(nil, location)
+        end
+      end
+    end
+  end
+end

--- a/ruby/lib/gherkin3/scanners/fail_scanner.rb
+++ b/ruby/lib/gherkin3/scanners/fail_scanner.rb
@@ -1,0 +1,11 @@
+require 'gherkin3/scanners/basic_scanner'
+
+module Gherkin3
+  module Scanners
+    class FailScanner < BasicScanner
+      def self.match?(*)
+        fail ArgumentError, 'Please a pass "String", "Pathname", path to file as "String" or "IO".'
+      end
+    end
+  end
+end

--- a/ruby/lib/gherkin3/scanners/file_scanner.rb
+++ b/ruby/lib/gherkin3/scanners/file_scanner.rb
@@ -1,0 +1,22 @@
+require 'pathname'
+require 'gherkin3/scanners/basic_scanner'
+
+module Gherkin3
+  module Scanners
+    class FileScanner < BasicScanner
+      def initialize(input)
+        super
+
+        @io = if String === input
+                File.open(input, 'r:BOM|UTF-8')
+              else
+                input.open
+              end
+      end
+
+      def self.match?(input)
+        File.file?(input.to_s) || Pathname === input
+      end
+    end
+  end
+end

--- a/ruby/lib/gherkin3/scanners/io_scanner.rb
+++ b/ruby/lib/gherkin3/scanners/io_scanner.rb
@@ -1,0 +1,17 @@
+require 'gherkin3/scanners/basic_scanner'
+
+module Gherkin3
+  module Scanners
+    class IOScanner < BasicScanner
+      def initialize(input)
+        super
+
+        @io = input
+      end
+
+      def self.match?(input)
+        input.is_a? IO
+      end
+    end
+  end
+end

--- a/ruby/lib/gherkin3/scanners/string_scanner.rb
+++ b/ruby/lib/gherkin3/scanners/string_scanner.rb
@@ -1,0 +1,18 @@
+require 'stringio'
+require 'gherkin3/scanners/basic_scanner'
+
+module Gherkin3
+  module Scanners
+    class StringScanner < BasicScanner
+      def initialize(input)
+        super
+
+        @io = StringIO.new(input)
+      end
+
+      def self.match?(input)
+        String === input
+      end
+    end
+  end
+end

--- a/ruby/lib/gherkin3/token_scanner.rb
+++ b/ruby/lib/gherkin3/token_scanner.rb
@@ -1,8 +1,9 @@
-require_relative 'token'
-require_relative 'gherkin_line'
+require 'gherkin3/scanners/file_scanner'
+require 'gherkin3/scanners/string_scanner'
+require 'gherkin3/scanners/io_scanner'
+require 'gherkin3/scanners/fail_scanner'
 
 module Gherkin3
-  
   # The scanner reads a gherkin doc (typically read from a .feature file) and 
   # creates a token for line. The tokens are passed to the parser, which outputs 
   # an AST (Abstract Syntax Tree).
@@ -11,31 +12,20 @@ module Gherkin3
   # to look for Gherkin keywords for the associated language. The keywords are defined 
   # in gherkin-languages.json.
   class TokenScanner
-
-    def initialize(source_or_path_or_io)
+    def initialize(input)
       @line_number = 0
-      if String === source_or_path_or_io
-        if File.file?(source_or_path_or_io)
-          @io = File.open(source_or_path_or_io, 'r:BOM|UTF-8')
-        else
-          @io = StringIO.new(source_or_path_or_io)
-        end
-      else
-        @io = source_or_path_or_io
-      end
+
+      @token_scanner = [
+        Scanners::FileScanner,
+        Scanners::StringScanner,
+        Scanners::IOScanner,
+        Scanners::FailScanner
+      ].find { |s| s.match? input }.new(input)
     end
 
+    # Read tokens
     def read
-      location = {line: @line_number += 1}
-      if @io.nil? || line = @io.gets
-        gherkin_line = line ? GherkinLine.new(line, location[:line]) : nil
-        Token.new(gherkin_line, location)
-      else
-        @io.close unless @io.closed? # ARGF closes the last file after final gets
-        @io = nil
-        Token.new(nil, location)
-      end
+      @token_scanner.read
     end
-
   end
 end

--- a/ruby/spec/gherkin3/parser_spec.rb
+++ b/ruby/spec/gherkin3/parser_spec.rb
@@ -23,6 +23,59 @@ module Gherkin3
       })
     end
 
+    it "parses string feature" do
+      parser = Parser.new
+      ast = parser.parse("Feature: test")
+      expect(ast).to eq({
+        type: :Feature,
+        tags: [],
+        location: {line: 1, column: 1},
+        language: "en",
+        keyword: "Feature",
+        name: "test",
+        scenarioDefinitions: [],
+        comments: []
+      })
+    end
+
+    it "parses file path feature", :type => :aruba do
+      write_file 'features/my_feature.feature', "Feature: test"
+      feature_file_path = expand_path 'features/my_feature.feature'
+
+      parser = Parser.new
+      ast = parser.parse(feature_file_path)
+
+      expect(ast).to eq({
+        type: :Feature,
+        tags: [],
+        location: {line: 1, column: 1},
+        language: "en",
+        keyword: "Feature",
+        name: "test",
+        scenarioDefinitions: [],
+        comments: []
+      })
+    end
+
+    it "parses file io feature", :type => :aruba do
+      write_file 'features/my_feature.feature', "Feature: test"
+      feature_file_path = expand_path 'features/my_feature.feature'
+
+      parser = Parser.new
+      ast = parser.parse(File.open(feature_file_path))
+
+      expect(ast).to eq({
+        type: :Feature,
+        tags: [],
+        location: {line: 1, column: 1},
+        language: "en",
+        keyword: "Feature",
+        name: "test",
+        scenarioDefinitions: [],
+        comments: []
+      })
+    end
+
     it "can parse multiple features" do
       parser = Parser.new
       ast1 = parser.parse(TokenScanner.new("Feature: test"))


### PR DESCRIPTION
Follow up to #97

* `Parser#parse` accepts strings, io, file
* `TokenScanner#new` gets io from another `TokenScanner`-instance to make it backward compatible
* `Parser#parse` uses `TokenScanner` directly to give different inputs - io, file, string, token_scanner - a sane API