### PR TITLE
Improve test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Gherkin 3 is currently implemented for the following platforms:
 * Go
 * Python
 
-See `CONTRIBUTING.md` if you want to contribute a parser for a new language.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) if you want to contribute a parser for a new language.
 Our wish-list is (in no particular order):
 
 * C
@@ -250,4 +250,4 @@ The various compilers producing pickles might move to a separate project too.
 
 ## Building Gherkin 3
 
-See `CONTRIBUTING.md`
+See [`CONTRIBUTING.md`](CONTRIBUTING.md)

--- a/ruby/.gitignore
+++ b/ruby/.gitignore
@@ -4,3 +4,4 @@ acceptance/
 .built
 .compared
 pkg/
+tmp/

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -9,5 +9,5 @@ following command to generate the ruby files.
 
 ~~~bash
 cd <project_root>/ruby
-bundle exec make
+make
 ~~~

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,3 +1,13 @@
 [![Build Status](https://secure.travis-ci.org/cucumber/gherkin-ruby.png)](http://travis-ci.org/cucumber/gherkin-ruby)
 
 Gherkin parser/compiler for Ruby. Please see [Gherkin3](https://github.com/cucumber/gherkin3) for details.
+
+## Developers
+
+Some files are generated from the `gherkin-ruby.razor` file. Please run the
+following command to generate the ruby files.
+
+~~~bash
+cd <project_root>/ruby
+bundle exec make
+~~~

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -7,7 +7,7 @@ $:.unshift File.expand_path("../lib", __FILE__)
 
 require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.ruby_opts  = %w[-r./spec/coverage -w]
+  t.ruby_opts  = %w[-r./spec/coverage -w -r aruba/rspec]
   t.rspec_opts = %w[--color]
 end
 

--- a/ruby/gherkin3.gemspec
+++ b/ruby/gherkin3.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler',   '~> 1.7'
   s.add_development_dependency 'rake',      '~> 10.4'
   s.add_development_dependency 'rspec',     '~> 3.3'
+  s.add_development_dependency 'aruba',     '~> 0.9'
 
   # For coverage reports
   s.add_development_dependency 'coveralls', '~> 0.8'

--- a/ruby/spec/gherkin3/parser_spec.rb
+++ b/ruby/spec/gherkin3/parser_spec.rb
@@ -23,6 +23,59 @@ module Gherkin3
       })
     end
 
+    it "parses string feature" do
+      parser = Parser.new
+      ast = parser.parse("Feature: test")
+      expect(ast).to eq({
+        type: :Feature,
+        tags: [],
+        location: {line: 1, column: 1},
+        language: "en",
+        keyword: "Feature",
+        name: "test",
+        scenarioDefinitions: [],
+        comments: []
+      })
+    end
+
+    it "parses file path feature", :type => :aruba do
+      write_file 'features/my_feature.feature', "Feature: test"
+      feature_file_path = expand_path 'features/my_feature.feature'
+
+      parser = Parser.new
+      ast = parser.parse(feature_file_path)
+
+      expect(ast).to eq({
+        type: :Feature,
+        tags: [],
+        location: {line: 1, column: 1},
+        language: "en",
+        keyword: "Feature",
+        name: "test",
+        scenarioDefinitions: [],
+        comments: []
+      })
+    end
+
+    it "parses file io feature", :type => :aruba do
+      write_file 'features/my_feature.feature', "Feature: test"
+      feature_file_path = expand_path 'features/my_feature.feature'
+
+      parser = Parser.new
+      ast = parser.parse(File.open(feature_file_path))
+
+      expect(ast).to eq({
+        type: :Feature,
+        tags: [],
+        location: {line: 1, column: 1},
+        language: "en",
+        keyword: "Feature",
+        name: "test",
+        scenarioDefinitions: [],
+        comments: []
+      })
+    end
+
     it "can parse multiple features" do
       parser = Parser.new
       ast1 = parser.parse(TokenScanner.new("Feature: test"))


### PR DESCRIPTION
Ok. Then, let's split the PR #98. This one only improves the test suite and will break the current implementation as this DOES not support the use of Strings as input for the `Gherkin::Parser`. @aslakhellesoy I hope the use of `aruba` is not "too" way off to violate CONTRIBUTING.md.