### PR TITLE
Fix problem with strings

### DIFF
--- a/ruby/gherkin-ruby.razor
+++ b/ruby/gherkin-ruby.razor
@@ -58,6 +58,8 @@ module Gherkin3
     end
 
     def parse(token_scanner, token_matcher=TokenMatcher.new)
+      token_scanner = token_scanner.is_a?(TokenScanner) ? token_scanner : TokenScanner.new(token_scanner)
+
       @@ast_builder.reset
       token_matcher.reset
       context = ParserContext.new(

--- a/ruby/lib/gherkin3/parser.rb
+++ b/ruby/lib/gherkin3/parser.rb
@@ -1,6 +1,7 @@
 # This file is generated. Do not edit! Edit gherkin-ruby.razor instead.
 require_relative 'ast_builder'
 require_relative 'token_matcher'
+require_relative 'token_scanner'
 require_relative 'errors'
 
 module Gherkin3
@@ -64,6 +65,8 @@ module Gherkin3
     end
 
     def parse(token_scanner, token_matcher=TokenMatcher.new)
+      token_scanner = token_scanner.is_a?(TokenScanner) ? token_scanner : TokenScanner.new(token_scanner)
+
       @ast_builder.reset
       token_matcher.reset
       context = ParserContext.new(

--- a/ruby/lib/gherkin3/token_scanner.rb
+++ b/ruby/lib/gherkin3/token_scanner.rb
@@ -2,7 +2,6 @@ require_relative 'token'
 require_relative 'gherkin_line'
 
 module Gherkin3
-  
   # The scanner reads a gherkin doc (typically read from a .feature file) and 
   # creates a token for line. The tokens are passed to the parser, which outputs 
   # an AST (Abstract Syntax Tree).
@@ -11,17 +10,15 @@ module Gherkin3
   # to look for Gherkin keywords for the associated language. The keywords are defined 
   # in gherkin-languages.json.
   class TokenScanner
-
-    def initialize(source_or_path_or_io)
+    def initialize(source_or_io)
       @line_number = 0
-      if String === source_or_path_or_io
-        if File.file?(source_or_path_or_io)
-          @io = File.open(source_or_path_or_io, 'r:BOM|UTF-8')
-        else
-          @io = StringIO.new(source_or_path_or_io)
-        end
+
+      if String === source_or_io
+        @io = StringIO.new(source_or_io)
+      elsif source_or_io.is_a? IO
+        @io = source_or_io
       else
-        @io = source_or_path_or_io
+        fail ArgumentError, 'Please a pass "String" or "IO".'
       end
     end
 

--- a/ruby/spec/gherkin3/parser_spec.rb
+++ b/ruby/spec/gherkin3/parser_spec.rb
@@ -23,6 +23,37 @@ module Gherkin3
       })
     end
 
+    it "parses string feature" do
+      parser = Parser.new
+      ast = parser.parse("Feature: test")
+      expect(ast).to eq({
+        type: :Feature,
+        tags: [],
+        location: {line: 1, column: 1},
+        language: "en",
+        keyword: "Feature",
+        name: "test",
+        scenarioDefinitions: [],
+        comments: []
+      })
+    end
+
+    it "parses io feature" do
+      parser = Parser.new
+      ast = parser.parse(StringIO.new("Feature: test"))
+
+      expect(ast).to eq({
+        type: :Feature,
+        tags: [],
+        location: {line: 1, column: 1},
+        language: "en",
+        keyword: "Feature",
+        name: "test",
+        scenarioDefinitions: [],
+        comments: []
+      })
+    end
+
     it "can parse multiple features" do
       parser = Parser.new
       ast1 = parser.parse(TokenScanner.new("Feature: test"))


### PR DESCRIPTION
This one is based on #99. #99 should be merge before this one is merged. With this PR you can pass `Parser#parse` a feature file as string.