### PR TITLE
ASCII art doesn't render properly on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ I wrote up a summary [here](https://groups.google.com/d/msg/cukes/YLKsqbBMBoI/DY
 The following diagram outlines the architecture:
 
     ╔════════════╗   ┌───────┐   ╔══════╗   ┌──────┐   ╔═══╗
-    ║Feature file║──▶│Scanner│──▶║Tokens║──▶│Parser│──▶║AST║
+    ║Feature file║──>│Scanner│──>║Tokens║──>│Parser│──>║AST║
     ╚════════════╝   └───────┘   ╚══════╝   └──────┘   ╚═══╝
 
 The *scanner* reads a gherkin doc (typically read from a `.feature` file) and creates
@@ -107,10 +107,10 @@ Berp takes a grammar file (`gherkin.berp`) and a template file (`gherkin-X.razor
 and outputs a parser in language *X*:
 
     ╔════════════╗   ┌────────┐   ╔═══════════════╗
-    ║gherkin.berp║──▶│berp.exe│◀──║gherkin-X.razor║
+    ║gherkin.berp║──>│berp.exe│<──║gherkin-X.razor║
     ╚════════════╝   └────────┘   ╚═══════════════╝
                           │
-                          ▼
+                          V
                      ╔════════╗
                      ║Parser.x║
                      ╚════════╝
@@ -148,7 +148,7 @@ The compiler compiles the AST produced by the parser
 into a simpler form - *Pickles*.
 
     ╔═══╗   ┌────────┐   ╔═══════╗
-    ║AST║──▶│Compiler│──▶║Pickles║
+    ║AST║──>│Compiler│──>║Pickles║
     ╚═══╝   └────────┘   ╚═══════╝
 
 The rationale is to decouple Gherkin from Cucumber so that Cucumber is open to
@@ -234,10 +234,10 @@ codebase until it settles:
             │             │             │                   │
     ┌───────┼─────────────┼─────────────┼───────┐           │
     │       │             │             │       │           │
-    │       ▼             ▼             ▼       │           ▼
+    │       V             V             V       │           V
     │  ┌─────────┐   ┌─────────┐   ┌─────────┐  │      ┌─────────┐
     │  │Gherkin3 │   │Gherkin3 │   │ Pickles │  │      │Markdown │
-    │  │ Parser  │   │Compiler │──▶│         │◀─┼──────│Parser / │
+    │  │ Parser  │   │Compiler │──>│         │<─┼──────│Parser / │
     │  └─────────┘   └─────────┘   └─────────┘  │      │Compiler │
     └───────────────────────────────────────────┘      └─────────┘
                      Gherkin3 lib


### PR DESCRIPTION
The characters used for the left and right arrows are not outside the
range of standard and extended ASCII characters and the font used by
Windows-based browsers doesn't render them at the same width as the rest
of the characters, so the box sides and corners do not line up.
I replaced the left and right arrow characters with the '<' and '>
characters so the boxes look right when viewed from a browser under
Windows. I also replaced the down arrow with a 'V', even though the down
arrow is the same width, so all the arrows look consistent.