### PR TITLE
Do not change escaped docstring separators in descriptions.

### DIFF
--- a/dotnet/Gherkin/TokenMatcher.cs
+++ b/dotnet/Gherkin/TokenMatcher.cs
@@ -226,7 +226,7 @@ namespace Gherkin
 
         private string UnescapeDocString(string text)
         {
-            return text.Replace("\\\"\\\"\\\"", "\"\"\"");
+            return activeDocStringSeparator != null ? text.Replace("\\\"\\\"\\\"", "\"\"\"") : text;
         }
     }
 }

--- a/go/matcher.go
+++ b/go/matcher.go
@@ -250,13 +250,17 @@ func (m *matcher) MatchOther(line *Line) (ok bool, token *Token, err error) {
 	txt := strings.TrimLeft(element, " ")
 
 	if len(element)-len(txt) > m.indentToRemove {
-		token.Text = unescapeDocString(element[m.indentToRemove:])
+		token.Text = m.unescapeDocString(element[m.indentToRemove:])
 	} else {
-		token.Text = unescapeDocString(txt)
+		token.Text = m.unescapeDocString(txt)
 	}
 	return
 }
 
-func unescapeDocString(text string) string {
-	return strings.Replace(text, "\\\"\\\"\\\"", "\"\"\"", -1)
+func (m *matcher) unescapeDocString(text string) string {
+	if m.activeDocStringSeparator != "" {
+		return strings.Replace(text, "\\\"\\\"\\\"", "\"\"\"", -1)
+	} else {
+		return text
+	}
 }

--- a/java/src/main/java/gherkin/TokenMatcher.java
+++ b/java/src/main/java/gherkin/TokenMatcher.java
@@ -193,7 +193,7 @@ public class TokenMatcher implements ITokenMatcher {
         return false;
     }
 
-    private static String unescapeDocString(String text) {
-        return text.replace("\\\"\\\"\\\"", "\"\"\"");
+    private String unescapeDocString(String text) {
+        return activeDocStringSeparator != null ? text.replace("\\\"\\\"\\\"", "\"\"\"") : text;
     }
 }

--- a/javascript/lib/gherkin/token_matcher.js
+++ b/javascript/lib/gherkin/token_matcher.js
@@ -184,6 +184,6 @@ module.exports = function TokenMatcher(defaultDialectName) {
   }
 
   function unescapeDocString(text) {
-    return text.replace("\\\"\\\"\\\"", "\"\"\"");
+    return activeDocStringSeparator != null ? text.replace("\\\"\\\"\\\"", "\"\"\"") : text;
   }
 };

--- a/objective-c/Gherkin/GHTokenMatcher.m
+++ b/objective-c/Gherkin/GHTokenMatcher.m
@@ -277,7 +277,7 @@
 
 - (NSString *)unescapeDocString:(NSString *)theText
 {
-    return [theText stringByReplacingOccurrencesOfString: @"\\\"\\\"\\\"" withString: @"\"\"\""];
+  return activeDocStringSeparator != nil ? [theText stringByReplacingOccurrencesOfString: @"\\\"\\\"\\\"" withString: @"\"\"\""] : [theText];
 }
 
 @end

--- a/python/gherkin3/token_matcher.py
+++ b/python/gherkin3/token_matcher.py
@@ -155,4 +155,4 @@ class TokenMatcher(object):
         self.dialect = dialect
 
     def _unescaped_docstring(self, text):
-        return text.replace('\\"\\"\\"', '"""')
+        return text.replace('\\"\\"\\"', '"""') if self._active_doc_string_separator else text

--- a/ruby/lib/gherkin3/token_matcher.rb
+++ b/ruby/lib/gherkin3/token_matcher.rb
@@ -163,7 +163,7 @@ module Gherkin3
     end
 
     def unescape_docstring(text)
-      text.gsub("\\\"\\\"\\\"", "\"\"\"")
+      @active_doc_string_separator ? text.gsub("\\\"\\\"\\\"", "\"\"\"") : text
     end
   end
 end

--- a/testdata/good/descriptions.feature
+++ b/testdata/good/descriptions.feature
@@ -37,6 +37,11 @@ This is a description without indentation
 
     Given the minimalism
 
+  Scenario: description with escaped docstring separator
+  This description has an \"\"\" (escaped docstring sparator)
+
+    Given the minimalism
+
   Scenario Outline: scenario outline with a description
 This is a scenario outline description
     Given the minimalism

--- a/testdata/good/descriptions.feature.ast.json
+++ b/testdata/good/descriptions.feature.ast.json
@@ -159,6 +159,28 @@
       "type": "Scenario"
     },
     {
+      "description": "  This description has an \\\"\\\"\\\" (escaped docstring sparator)",
+      "keyword": "Scenario",
+      "location": {
+        "column": 3,
+        "line": 40
+      },
+      "name": "description with escaped docstring separator",
+      "steps": [
+        {
+          "keyword": "Given ",
+          "location": {
+            "column": 5,
+            "line": 43
+          },
+          "text": "the minimalism",
+          "type": "Step"
+        }
+      ],
+      "tags": [],
+      "type": "Scenario"
+    },
+    {
       "description": "This is a scenario outline description",
       "examples": [
         {
@@ -166,7 +188,7 @@
           "keyword": "Examples",
           "location": {
             "column": 3,
-            "line": 44
+            "line": 49
           },
           "name": "examples with description",
           "tableBody": [
@@ -175,7 +197,7 @@
                 {
                   "location": {
                     "column": 7,
-                    "line": 47
+                    "line": 52
                   },
                   "type": "TableCell",
                   "value": "bar"
@@ -183,7 +205,7 @@
               ],
               "location": {
                 "column": 5,
-                "line": 47
+                "line": 52
               },
               "type": "TableRow"
             }
@@ -193,7 +215,7 @@
               {
                 "location": {
                   "column": 7,
-                  "line": 46
+                  "line": 51
                 },
                 "type": "TableCell",
                 "value": "foo"
@@ -201,7 +223,7 @@
             ],
             "location": {
               "column": 5,
-              "line": 46
+              "line": 51
             },
             "type": "TableRow"
           },
@@ -212,7 +234,7 @@
       "keyword": "Scenario Outline",
       "location": {
         "column": 3,
-        "line": 40
+        "line": 45
       },
       "name": "scenario outline with a description",
       "steps": [
@@ -220,7 +242,7 @@
           "keyword": "Given ",
           "location": {
             "column": 5,
-            "line": 42
+            "line": 47
           },
           "text": "the minimalism",
           "type": "Step"

--- a/testdata/good/descriptions.feature.pickles.json
+++ b/testdata/good/descriptions.feature.pickles.json
@@ -140,12 +140,35 @@
   {
     "locations": [
       {
+        "column": 3,
+        "line": 40
+      }
+    ],
+    "name": "Scenario: description with escaped docstring separator",
+    "path": "../testdata/good/descriptions.feature",
+    "steps": [
+      {
+        "arguments": [],
+        "locations": [
+          {
+            "column": 11,
+            "line": 43
+          }
+        ],
+        "text": "the minimalism"
+      }
+    ],
+    "tags": []
+  },
+  {
+    "locations": [
+      {
         "column": 5,
-        "line": 47
+        "line": 52
       },
       {
         "column": 3,
-        "line": 40
+        "line": 45
       }
     ],
     "name": "Scenario: scenario outline with a description",
@@ -156,11 +179,11 @@
         "locations": [
           {
             "column": 5,
-            "line": 47
+            "line": 52
           },
           {
             "column": 11,
-            "line": 42
+            "line": 47
           }
         ],
         "text": "the minimalism"

--- a/testdata/good/descriptions.feature.tokens
+++ b/testdata/good/descriptions.feature.tokens
@@ -37,12 +37,17 @@
 (37:1)Empty://
 (38:5)StepLine:Given /the minimalism/
 (39:1)Empty://
-(40:3)ScenarioOutlineLine:Scenario Outline/scenario outline with a description/
-(41:1)Other:/This is a scenario outline description/
-(42:5)StepLine:Given /the minimalism/
-(43:1)Empty://
-(44:3)ExamplesLine:Examples/examples with description/
-(45:1)Other:/This is an examples description/
-(46:5)TableRow://7:foo
-(47:5)TableRow://7:bar
+(40:3)ScenarioLine:Scenario/description with escaped docstring separator/
+(41:1)Other:/  This description has an \"\"\" (escaped docstring sparator)/
+(42:1)Other://
+(43:5)StepLine:Given /the minimalism/
+(44:1)Empty://
+(45:3)ScenarioOutlineLine:Scenario Outline/scenario outline with a description/
+(46:1)Other:/This is a scenario outline description/
+(47:5)StepLine:Given /the minimalism/
+(48:1)Empty://
+(49:3)ExamplesLine:Examples/examples with description/
+(50:1)Other:/This is an examples description/
+(51:5)TableRow://7:foo
+(52:5)TableRow://7:bar
 EOF


### PR DESCRIPTION
Now the unescaping of docstring separators is performed unconditionally when matching the token "other". Since the token "other" is used both for descriptions and docstrings, also in descriptions `\"\"\"` is replaced with `"""` (why anyone would write `\"\"\"` in a description is another question).

This PR changes the behaviour so that only in docstrings  `\"\"\"` is replaced with `"""`.