### PR TITLE
Prevent token_scanner.py from (recklessly) monkey-patching io.StringIO.

### DIFF
--- a/python/gherkin3/token_scanner.py
+++ b/python/gherkin3/token_scanner.py
@@ -2,11 +2,11 @@ import io
 import os
 from .token import Token
 from .gherkin_line import GherkinLine
+
 try:
     from cStringIO import StringIO
-    io.StringIO = StringIO
 except ImportError:
-    pass
+    StringIO = io.StringIO
 
 
 class TokenScanner(object):
@@ -26,7 +26,7 @@ class TokenScanner(object):
             if os.path.exists(path_or_str):
                 self.io = io.open(path_or_str, 'rU', encoding='utf8')
             else:
-                self.io = io.StringIO(path_or_str)
+                self.io = StringIO(path_or_str)
         self.line_number = 0
 
     def read(self):


### PR DESCRIPTION
By monkey-patching `io.StringIO` to be `cStringIO.StringIO`, `token_scanner.py` was inadvertently breaking breaking any code that expected `io.StringIO` to be of type `type`, because `cStringIO.StringIO` has type `builtin_function_or_method`.

Practically speaking, this means that any code that attempted to interact with `io.StringIO` as one would interact with a class (e.g. subclassing, accessing a class attribute, etc) would fail with an error, for example:
* Subclassing: `TypeError: Error when calling the metaclass bases`
* Attribute access: `AttributeError: 'builtin_function_or_method' object has no attribute 'write'`

The [Celery](https://github.com/celery/celery/) project does exactly this in the `celery.five` [module](https://github.com/celery/celery/blob/v3.1.16/celery/five.py#L383-L387), which is how I encountered this error.