### PR TITLE
Build objective-c on Travis. Fix Travis language settings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,34 +6,64 @@ sudo: false
 matrix:
   include:
     - env: TARGET_LANG=java
+      language: java
       jdk: oraclejdk8
+      before_install:
+        # https://github.com/travis-ci/travis-ci/issues/2839
+        - export JAVA_HOME="$(/usr/libexec/java_home)"
 
     - env: TARGET_LANG=ruby
+      language: ruby
       rvm: 2.0.0
+      before_install:
+        # for some ruby version the bunlder version becomes
+        # 1.6.9 if not installed explicitly
+        - gem install bundler -v 1.7.9
     - env: TARGET_LANG=ruby
+      language: ruby
       rvm: 2.1.0
+      before_install:
+        - gem install bundler -v 1.7.9
     - env: TARGET_LANG=ruby
+      language: ruby
       rvm: 2.2.0
+      before_install:
+        - gem install bundler -v 1.7.9
     - env: TARGET_LANG=ruby
-      rvm: jruby-head
+      language: ruby
+      rvm: jruby-1.7.22
+      before_install:
+        - gem install bundler -v 1.7.9
 
     - env: TARGET_LANG=javascript
+      language: javascript
       node_js: 0.10.40
     - env: TARGET_LANG=javascript
+      language: javascript
       node_js: 4.1.2
 
     - env: TARGET_LANG=go
+      language: go
       go: latest
 
     - env: TARGET_LANG=python
+      language: python
       python: "2.7"
+      install: "pip install -r $TARGET_LANG/requirements.txt"
     - env: TARGET_LANG=python
+      language: python
       python: "3.4"
+      install: "pip install -r $TARGET_LANG/requirements.txt"
+
+    - env: TARGET_LANG=objective-c
+      language: objective-c
+      os: osx
+      osx_image: xcode7
+      before_script:
+        - brew install jq
 
 before_install:
   - export EnableNuGetPackageRestore=true
-  # https://github.com/travis-ci/travis-ci/issues/2839
-  - export JAVA_HOME="$(/usr/libexec/java_home)"
 
 addons:
   apt:

--- a/objective-c/.travis.yml
+++ b/objective-c/.travis.yml
@@ -1,4 +1,9 @@
 language: objective-c
-os:
-  - osx
-script: "make test"
+os: osx
+osx_image: xcode7
+script: 
+ - xcodebuild -version
+ - xcodebuild -scheme "GherkinOSX" -configuration Debug CONFIGURATION_BUILD_DIR=build/
+ - xcodebuild -scheme "AstGenerator" CONFIGURATION_BUILD_DIR=build/
+ - xcodebuild -scheme "TokensGenerator" CONFIGURATION_BUILD_DIR=build/
+ # - xcodebuild test -scheme "GherkinTestsOSX"

--- a/python/Makefile
+++ b/python/Makefile
@@ -14,6 +14,7 @@ all: .compared
 	touch $@
 
 .built: show-version-info gherkin3/parser.py gherkin3/gherkin-languages.json $(PYTHON_FILES) LICENSE.txt
+	nosetests
 	touch $@
 
 show-version-info:


### PR DESCRIPTION
Build (including the acceptance tests) the objective-c version on the top Travis build. Compile the objective-c version on the gherkin-objective-c Travis build.

Set the language explicitly on all jobs in the Travis matrix, otherwise the default version of the language is used instead of the specified one. That means that in theory we have tested on 4 different Ruby version and 2 different Python version, but in practice we have only tested on Ruby 1.9.3 and Python 2.7.3 (see https://travis-ci.org/cucumber/gherkin3/jobs/84295786#L1108 and https://travis-ci.org/cucumber/gherkin3/jobs/89541942#L1107)

Use jruby 1.7.22 instead of jruby-head, the jruby-head version issues warnings that interfere with the error tests (see https://travis-ci.org/cucumber/gherkin3/jobs/89730239#L430).

Run the unit tests (nosetests) also for the Python version on the top Travis build.

Fixes #118. 