### PR TITLE
Add gnéchlár for feature for irish

### DIFF
--- a/dotnet/Gherkin/gherkin-languages.json
+++ b/dotnet/Gherkin/gherkin-languages.json
@@ -1023,7 +1023,8 @@
       "Samplaí"
     ],
     "feature": [
-      "Gné"
+      "Gné",
+      "Ghnéchlár"
     ],
     "given": [
       "* ",


### PR DESCRIPTION
Gnéchlár is a more correct word for a software feature in irish.